### PR TITLE
Introducing code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# https://help.github.com/en/articles/about-code-owners
+# Everything is owned by Technical Writers
+* @corda/technical-writers
+
+# Except for configuration for CI...
+/.ci @corda/infrastructure
+# ... and Github
+/.github @corda/infrastructure


### PR DESCRIPTION
* see https://help.github.com/en/articles/about-code-owners
* Technical Writers own everything...
* ...except for Jenkins and Github settings (for now)