### PR TITLE
ENT-4416: Documentation update for the metering category

### DIFF
--- a/content/en/docs/corda-enterprise/4.4/node-metrics.md
+++ b/content/en/docs/corda-enterprise/4.4/node-metrics.md
@@ -78,6 +78,7 @@ weightPercent are only available for weight-based caches.
 |net.corda:type=Flows,name=QueueSizeOnInsert|Histogram showing the queue size at the point new flows are added|
 |net.corda:type=Flows,name=Started|The total number of flows started|
 |net.corda:type=Flows,name=Success|The total number of successful flows|
+|net.corda:type=Flows,component=Actions,name=<action_name>>|Histogram indicating the elapsed time to execute a particular action|
 
 {{< /table >}}
 


### PR DESCRIPTION
Please see [Jira](https://r3-cev.atlassian.net/browse/ENT-4416) for specific details.

I am updating CE 4.4 documentation because:
 - CE 4.5 documentation does not exist yet. But hopefully when created 4.4 content will be copied;
 - The metric equally applies to CE 4.4 as well.