### PR TITLE
EG-1589: Fixing a typo across a couple of versions.

### DIFF
--- a/content/en/docs/corda-enterprise/4.3/quickstart-index.md
+++ b/content/en/docs/corda-enterprise/4.3/quickstart-index.md
@@ -31,7 +31,7 @@ Getting started with Corda will walk you through the process of setting up a dev
 ### Prerequisites
 
 
-* **Java 8 JVK** - We require at least version 8u171, but do not currently support Java 9 or higher.
+* **Java 8 JDK** - We require at least version 8u171, but do not currently support Java 9 or higher.
 * **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version 1.2.71).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
 

--- a/content/en/docs/corda-enterprise/4.4/cordapps/quickstart-index.md
+++ b/content/en/docs/corda-enterprise/4.4/cordapps/quickstart-index.md
@@ -32,7 +32,7 @@ Getting started with Corda will walk you through the process of setting up a dev
 ### Prerequisites
 
 
-* **Java 8 JVK** - We require at least version 8u171, but do not currently support Java 9 or higher.
+* **Java 8 JDK** - We require at least version 8u171, but do not currently support Java 9 or higher.
 * **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version 1.2.71).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
 

--- a/content/en/docs/corda-os/4.1/quickstart-index.md
+++ b/content/en/docs/corda-os/4.1/quickstart-index.md
@@ -31,7 +31,7 @@ Getting started with Corda will walk you through the process of setting up a dev
 ### Prerequisites
 
 
-* **Java 8 JVK** - We require at least version 8u171, but do not currently support Java 9 or higher.
+* **Java 8 JDK** - We require at least version 8u171, but do not currently support Java 9 or higher.
 * **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version 1.2.71).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
 

--- a/content/en/docs/corda-os/4.3/quickstart-index.md
+++ b/content/en/docs/corda-os/4.3/quickstart-index.md
@@ -31,7 +31,7 @@ Getting started with Corda will walk you through the process of setting up a dev
 ### Prerequisites
 
 
-* **Java 8 JVK** - We require at least version 8u171, but do not currently support Java 9 or higher.
+* **Java 8 JDK** - We require at least version 8u171, but do not currently support Java 9 or higher.
 * **IntelliJ IDEA** - IntelliJ is an IDE that offers strong support for Kotlin and Java development. We support versions **2017.x**, **2018.x** and **2019.x** (with Kotlin plugin version 1.2.71).
 * **Git** - We use Git to host our sample CorDapp and provide version control.
 


### PR DESCRIPTION
- Doc incorrectly specified Java 8 *JVK*. Changed to Java 8 *JDK*.

Signed-off-by: Ed Prosser <edward.prosser@r3.com>