### PR TITLE
[EG-1526] Final release notes for CE 4.2.1 and CE 4.4.1 - more fixes

### DIFF
--- a/content/en/docs/corda-enterprise/4.2/release-notes-enterprise.md
+++ b/content/en/docs/corda-enterprise/4.2/release-notes-enterprise.md
@@ -23,13 +23,13 @@ Corda Enterprise 4.2.1 is a patch release of Corda Enterprise 4.2 that introduce
 
 ### Upgrade recommendation
 
-As a developer, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html) as soon as possible. Check the latest Corda Enterprise release notes and upgrade guide [here](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html).
+As a developer, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/index.html) as soon as possible. Check the latest Corda Enterprise release notes and upgrade guide [here](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html).
 
-As a node operator, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html) if the fixed issue listed below is relevant to your work.
+As a node operator, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/index.html) if the fixed issue listed below is relevant to your work.
 
 ### Fixed issues
 
-* A recent JDK update has broken the way we used delegated signatures for TLS (Transport Layer Security) handshakes. We have fixed this issue through patches on all affected Corda Enterprise versions (4.2+) to allow users to upgrade to the latest versions of compatible JDK distributions. If you have not upgraded to one of the patched releases yet, do not upgrade to Java 8 version `8u252` or higher.
+A recent JDK update has broken the way we used delegated signatures for TLS (Transport Layer Security) handshakes. We have fixed this issue through patches on all affected Corda Enterprise versions (4.2+) to allow users to upgrade to the latest versions of compatible JDK distributions. If you have not upgraded to one of the patched releases yet, do not upgrade to Java 8 version `8u252` or higher.
 
 ## Corda Enterprise 4.2
 

--- a/content/en/docs/corda-enterprise/4.4/release-notes-enterprise.md
+++ b/content/en/docs/corda-enterprise/4.4/release-notes-enterprise.md
@@ -24,9 +24,9 @@ Corda Enterprise 4.4.1 is a patch release of Corda Enterprise that introduces fi
 
 ### Upgrade recommendation
 
-As a developer, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html) as soon as possible. Check the latest Corda Enterprise release notes and upgrade guide [here](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html).
+As a developer, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/index.html) as soon as possible. Check the latest Corda Enterprise release notes and upgrade guide [here](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html).
 
-As a node operator, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/release-notes-index.html) if any of the fixed issues listed below is relevant to your work.
+As a node operator, you should upgrade to the [latest released version of Corda](https://docs.corda.net/docs/corda-enterprise/index.html) if any of the fixed issues listed below is relevant to your work.
 
 ### Fixed issues
 

--- a/content/en/docs/corda-enterprise/4.4/release-notes-enterprise.md
+++ b/content/en/docs/corda-enterprise/4.4/release-notes-enterprise.md
@@ -32,7 +32,7 @@ As a node operator, you should upgrade to the [latest released version of Corda]
 
 * A recent JDK update has broken the way we used delegated signatures for TLS (Transport Layer Security) handshakes. We have fixed this issue through patches on all affected Corda Enterprise versions (4.2+) to allow users to upgrade to the latest versions of compatible JDK distributions. If you have not upgraded to one of the patched releases yet, do not upgrade to Java 8 version `8u252` or higher.
 * Fixed an issue to prevent `IndexOutOfBoundsException` from being thrown when serialising a `FlowAsyncOperation` that has maintained a reference to a `FlowLogic`. This issue occurred when constructing a `FlowAsyncOperation` from a `FlowExternalOperation` [[CORDA-3704](https://r3-cev.atlassian.net/browse/CORDA-3704)].
-* Removed references to unavailable man command in CRaSH and fixed syntax of output-format command [[CORDA-3688](https://r3-cev.atlassian.net/browse/CORDA-3688)].
+* Removed references to unavailable `man` command in CRaSH and fixed syntax of `output-format` command [[CORDA-3688](https://r3-cev.atlassian.net/browse/CORDA-3688)].
 * Resolved a race condition in `FlowLogic.waitForLedgerCommit`.
 * Addressed the following problems with the JPA notary:
     * Prevent database connection leak on unexpected DB exceptions.


### PR DESCRIPTION
Updated latest doc index links in both files and moved the single fixed issue in 4.2.1 from a bullet point to a normal para.