### PR TITLE
EG-2463 Removing Inaccurate SQLServer information

### DIFF
--- a/content/en/docs/corda-os/4.0/node-database.md
+++ b/content/en/docs/corda-os/4.0/node-database.md
@@ -56,31 +56,6 @@ on the standard schema search path according to the
 the schema search path must be set explicitly for the user.
 
 
-### SQLServer
-
-Nodes also have untested support for Microsoft SQL Server 2017, using Microsoft JDBC Driver 6.2 for SQL Server. Here is
-an example node configuration for SQLServer:
-
-```groovy
-dataSourceProperties = {
-    dataSourceClassName = "com.microsoft.sqlserver.jdbc.SQLServerDataSource"
-    dataSource.url = "jdbc:sqlserver://[HOST]:[PORT];databaseName=[DATABASE_NAME]"
-    dataSource.user = [USER]
-    dataSource.password = [PASSWORD]
-}
-database = {
-    transactionIsolationLevel = READ_COMMITTED
-}
-jarDirs = ["[FULL_PATH]/sqljdbc_6.2/enu/"]
-```
-
-Note that:
-
-
-* Ensure the directory referenced by jarDirs contains only one JDBC driver JAR file; by the default,
-sqljdbc_6.2/enu/contains two JDBC JAR files for different Java versions.
-
-
 ## Node database tables
 
 By default, the node database has the following tables:

--- a/content/en/docs/corda-os/4.1/node-database.md
+++ b/content/en/docs/corda-os/4.1/node-database.md
@@ -64,33 +64,6 @@ CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 
 ```
 
 
-
-
-### SQLServer
-
-Nodes also have untested support for Microsoft SQL Server 2017, using Microsoft JDBC Driver 6.2 for SQL Server. Here is
-an example node configuration for SQLServer:
-
-```groovy
-dataSourceProperties = {
-    dataSourceClassName = "com.microsoft.sqlserver.jdbc.SQLServerDataSource"
-    dataSource.url = "jdbc:sqlserver://[HOST]:[PORT];databaseName=[DATABASE_NAME]"
-    dataSource.user = [USER]
-    dataSource.password = [PASSWORD]
-}
-database = {
-    transactionIsolationLevel = READ_COMMITTED
-}
-jarDirs = ["[FULL_PATH]/sqljdbc_6.2/enu/"]
-```
-
-Note that:
-
-
-* Ensure the directory referenced by jarDirs contains only one JDBC driver JAR file; by the default,
-sqljdbc_6.2/enu/contains two JDBC JAR files for different Java versions.
-
-
 ## Node database tables
 
 By default, the node database has the following tables:

--- a/content/en/docs/corda-os/4.3/node-database.md
+++ b/content/en/docs/corda-os/4.3/node-database.md
@@ -66,31 +66,6 @@ CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 
 
 
 
-### SQLServer
-
-Nodes also have untested support for Microsoft SQL Server 2017, using Microsoft JDBC Driver 6.4 for SQL Server. Here is
-an example node configuration for SQLServer:
-
-```groovy
-dataSourceProperties = {
-    dataSourceClassName = "com.microsoft.sqlserver.jdbc.SQLServerDataSource"
-    dataSource.url = "jdbc:sqlserver://[HOST]:[PORT];databaseName=[DATABASE_NAME]"
-    dataSource.user = [USER]
-    dataSource.password = [PASSWORD]
-}
-database = {
-    transactionIsolationLevel = READ_COMMITTED
-}
-jarDirs = ["[FULL_PATH]/sqljdbc_6.4/enu/"]
-```
-
-Note that:
-
-
-* Ensure the directory referenced by jarDirs contains only one JDBC driver JAR file; by default, the
-`sqljdbc_6.4/enu/` contains multiple JDBC JAR files for different Java versions.
-
-
 ## Node database tables
 
 By default, the node database has the following tables:

--- a/content/en/docs/corda-os/4.4/node-database.md
+++ b/content/en/docs/corda-os/4.4/node-database.md
@@ -71,32 +71,6 @@ CREATE SEQUENCE my_schema.hibernate_sequence INCREMENT BY 1 MINVALUE 1 MAXVALUE 
 
 * The PostgreSQL JDBC database driver must be placed in the `drivers` directory in the node.
 
-
-### SQLServer
-
-Nodes also have untested support for Microsoft SQL Server 2017, using Microsoft JDBC Driver 6.4 for SQL Server. Here is
-an example node configuration for SQLServer:
-
-```groovy
-dataSourceProperties = {
-    dataSourceClassName = "com.microsoft.sqlserver.jdbc.SQLServerDataSource"
-    dataSource.url = "jdbc:sqlserver://[HOST]:[PORT];databaseName=[DATABASE_NAME]"
-    dataSource.user = [USER]
-    dataSource.password = [PASSWORD]
-}
-database = {
-    transactionIsolationLevel = READ_COMMITTED
-}
-jarDirs = ["[FULL_PATH]/sqljdbc_6.4/enu/"]
-```
-
-Note that:
-
-
-* Ensure the directory referenced by jarDirs contains only one JDBC driver JAR file; by default, the
-`sqljdbc_6.4/enu/` contains multiple JDBC JAR files for different Java versions.
-
-
 ## Node database tables
 
 By default, the node database has the following tables:


### PR DESCRIPTION
Inaccurate information removed from Corda OS 4.4, 4.3, 4.1, and 4.0. It did not appear in older versions.