### PR TITLE
[EG-2501] Adding missing navigation to features-versions.md

### DIFF
--- a/content/en/docs/corda-enterprise/4.4/features-versions.md
+++ b/content/en/docs/corda-enterprise/4.4/features-versions.md
@@ -4,15 +4,19 @@ aliases:
 - /docs/corda-enterprise/head/features-versions.html
 - /docs/corda-enterprise/features-versions.html
 date: '2020-01-08T09:59:25Z'
-menu: []
+menu:
+  corda-enterprise-4-4:
+    parent: corda-enterprise-4-4-upgrading-and-tools   
 tags:
-- features
-- versions
-title: Corda Features to Versions
+  - features
+  - versions
+  - platform versions
+title: Corda features and versions
+weight: 2
 ---
 
 
-# Corda Features to Versions
+# Corda features and versions
 
 New versions of Corda introduce new features. These fall into one of three categories which have subtle but important implications for
 node owners, application developers and network operators.
@@ -47,7 +51,7 @@ of Corda as well as opt in to newer features should they happen to be available 
 {{< table >}}
 
 
-# Corda Features
+# Corda features
 
 |Feature|Corda Platform Version (PV)|Min Network Platform Version (network mPV)|Introduced in OS version|Introduced in Enterprise version|
 |--------------------|--------------------|--------------------|--------------------|--------------------|

--- a/content/en/docs/corda-enterprise/4.4/platform-support-matrix.md
+++ b/content/en/docs/corda-enterprise/4.4/platform-support-matrix.md
@@ -12,7 +12,7 @@ tags:
 - support
 - matrix
 title: Platform support matrix
-weight: 3
+weight: 4
 ---
 
 

--- a/content/en/docs/corda-enterprise/4.4/release-notes-index.md
+++ b/content/en/docs/corda-enterprise/4.4/release-notes-index.md
@@ -13,7 +13,7 @@ tags:
 - release
 - notes
 title: Release notes and changelog
-weight: 4
+weight: 5
 ---
 
 

--- a/content/en/docs/corda-enterprise/4.4/tools-index.md
+++ b/content/en/docs/corda-enterprise/4.4/tools-index.md
@@ -12,6 +12,7 @@ menu:
 tags:
 - tools
 title: Corda Tools
+weight: 6
 ---
 
 

--- a/content/en/docs/corda-enterprise/4.4/version-compatibility.md
+++ b/content/en/docs/corda-enterprise/4.4/version-compatibility.md
@@ -11,7 +11,7 @@ tags:
 - version
 - compatibility
 title: Corda and Corda Enterprise compatibility
-weight: 2
+weight: 3
 ---
 
 

--- a/content/en/docs/corda-os/4.4/app-upgrade-notes.md
+++ b/content/en/docs/corda-os/4.4/app-upgrade-notes.md
@@ -10,7 +10,7 @@ date: '2020-01-08T09:59:25Z'
 menu:
   corda-os-4-4:
     identifier: corda-os-4-4-app-upgrade-notes
-    weight: 2
+    weight: 3
 tags:
 - app
 - upgrade

--- a/content/en/docs/corda-os/4.4/cheat-sheet.md
+++ b/content/en/docs/corda-os/4.4/cheat-sheet.md
@@ -10,7 +10,7 @@ date: '2020-01-08T09:59:25Z'
 menu:
   corda-os-4-4:
     identifier: corda-os-4-4-cheat-sheet
-    weight: 4
+    weight: 5
 tags:
 - cheat
 - sheet

--- a/content/en/docs/corda-os/4.4/corda-network/index.md
+++ b/content/en/docs/corda-os/4.4/corda-network/index.md
@@ -12,7 +12,7 @@ date: '2020-01-08T09:59:25Z'
 menu:
   corda-os-4-4:
     identifier: corda-os-4-4-corda-network
-    weight: 5
+    weight: 6
 title: Corda Network
 ---
 

--- a/content/en/docs/corda-os/4.4/features-versions.md
+++ b/content/en/docs/corda-os/4.4/features-versions.md
@@ -7,15 +7,19 @@ aliases:
 - /docs/corda-os/head/features-versions.html
 - /docs/corda-os/features-versions.html
 date: '2020-01-08T09:59:25Z'
-menu: []
+menu:
+  corda-os-4-4:
+    identifier: corda-os-4-4-features-versions
+    weight: 2
 tags:
 - features
 - versions
-title: Corda Features to Versions
+- platform versions
+title: Corda features and versions
 ---
 
 
-# Corda Features to Versions
+# Corda features and versions
 
 New versions of Corda introduce new features. These fall into one of three categories which have subtle but important implications for
 node owners, application developers and network operators.
@@ -50,7 +54,7 @@ of Corda as well as opt in to newer features should they happen to be available 
 {{< table >}}
 
 
-# Corda Features
+# Corda features
 
 |Feature|Corda Platform Version (PV)|Min Network Platform Version (network mPV)|Introduced in OS version|Introduced in Enterprise version|
 |--------------------|--------------------|--------------------|--------------------|--------------------|

--- a/content/en/docs/corda-os/4.4/node-upgrade-notes.md
+++ b/content/en/docs/corda-os/4.4/node-upgrade-notes.md
@@ -10,7 +10,7 @@ date: '2020-01-08T09:59:25Z'
 menu:
   corda-os-4-4:
     identifier: corda-os-4-4-node-upgrade-notes
-    weight: 3
+    weight: 4
 tags:
 - node
 - upgrade


### PR DESCRIPTION
Corda OS 4.4: Added "Corda features and versions" menu option immediately below the Release notes menu option in the Corda OS 4.4 navigation structure.

Corda Enterprise 4.4: Added  "Corda features and versions" menu option immediately below the Updating a CorDapp or node menu option in the Corda Enterprise 4.4 navigation structure.