### PR TITLE
EG-1969: DockerHub licensing documentation

### DIFF
--- a/content/en/docs/corda-enterprise/4.4/docker-image.md
+++ b/content/en/docs/corda-enterprise/4.4/docker-image.md
@@ -14,6 +14,10 @@ title: Official Corda Docker Image
 
 # Official Corda Docker Image
 
+{{< note >}}
+Note: Before running any Corda Docker images, you must accept the license agreement and indicate that you have done this by setting the environment variable `ACCEPT_LICENSE` to `YES` or `Y`. If you do not do this, none of the images will start.
+{{< /note >}}
+
 ## Running a node connected to a Compatibility Zone in Docker
 
 {{< note >}}


### PR DESCRIPTION
Adding a note to https://docs.corda.net/docs/corda-enterprise/4.4/docker-image.html about the ACCEPT_LICENSE parameter.

Does this need to be added to older versions of the docs? The page seems to exist all the way back to 4.0.