### PR TITLE
[EG-1572/EG-2080] [Docs] Update CorDapp quickstart and dev pages

### DIFF
--- a/content/en/docs/corda-enterprise/4.4/cordapps/tutorial-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.4/cordapps/tutorial-cordapp.md
@@ -93,18 +93,15 @@ The `cordapp-example` folder is structured as follows:
 │   ├── build.gradle
 │   └── src
 │       └── main
-            ├── java
+│           ├── java
 │           │   └── com
 │           │       └── example
 │           │           └── server
-│           │               └── JavaClientRpc
-│           ├── kotlin
-│           │   └── com
-│           │       └── example
-│           │           └── server
-│           │               ├── MainController.kt
-│           │               ├── NodeRPCConnection.kt
-│           │               └── Server.kt
+│           │               ├── CONSTANTS.java
+│           │               ├── MainController.java
+│           │               ├── NodeRPCConnection.java
+│           │               └── Server.java
+│           │               
 │           └── resources
 │               ├── application.properties
 │               └── public
@@ -208,13 +205,12 @@ The `cordapp-example` folder is structured as follows:
 ├── settings.gradle
 └── TRADEMARK
 
-
 ```
 
 The key files and directories are as follows:
 
 * The **root directory** contains some gradle files, a README, a LICENSE and a TRADEMARK statement
-* **clients** contains the source code for spring boot integration
+* **clients** contains the source code for Spring Boot integration
 * **config** contains log4j2 configs
 * **contracts-java** and **workflows-java** contain the source code for the example CorDapp written in Java
 * **contracts-kotlin** and **workflows-kotlin** contain the same source code, but written in Kotlin. CorDapps can be developed in either Java and Kotlin
@@ -250,15 +246,17 @@ The first step is to deploy the CorDapp to nodes running locally. To do this:
 ├── certificates
 ├── corda.jar              // The Corda node runtime
 ├── cordapps               // The node's CorDapps
-│   ├── corda-finance-contracts-4.4.jar
-│   ├── corda-finance-workflows-4.4.jar
-│   └── cordapp-example-0.1.jar
+│   ├── config
+│   ├── corda-example-contracts-0.1.jar
+│   └── corda-example-workflows-0.1.jar
+├── djvm
 ├── drivers
 ├── logs
 ├── network-parameters
 ├── node.conf              // The node's configuration file
 ├── nodeInfo-<HASH>        // The hash will be different each time you generate a node
-└── persistence.mv.db      // The node's database
+├── persistence.mv.db      // The node's database
+└── persistence.trace.db   // The node's database
 ```
 
 
@@ -282,7 +280,7 @@ Start a Spring Boot server for each node by opening a terminal/command prompt fo
 * Unix/Mac OSX: `./gradlew runPartyXServer`
 * Windows: `gradlew.bat runPartyXServer`
 
-Look for the "Started ServerKt in X seconds" message &mdash; don’t rely on the % indicator.
+Look for the `Started Server in X seconds` message &mdash; don’t rely on the % indicator.
 
 
 {{< warning >}}

--- a/content/en/docs/corda-enterprise/4.5/cordapps/tutorial-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.5/cordapps/tutorial-cordapp.md
@@ -93,18 +93,15 @@ The `cordapp-example` folder is structured as follows:
 │   ├── build.gradle
 │   └── src
 │       └── main
-            ├── java
+│           ├── java
 │           │   └── com
 │           │       └── example
 │           │           └── server
-│           │               └── JavaClientRpc
-│           ├── kotlin
-│           │   └── com
-│           │       └── example
-│           │           └── server
-│           │               ├── MainController.kt
-│           │               ├── NodeRPCConnection.kt
-│           │               └── Server.kt
+│           │               ├── CONSTANTS.java
+│           │               ├── MainController.java
+│           │               ├── NodeRPCConnection.java
+│           │               └── Server.java
+│           │               
 │           └── resources
 │               ├── application.properties
 │               └── public
@@ -208,13 +205,12 @@ The `cordapp-example` folder is structured as follows:
 ├── settings.gradle
 └── TRADEMARK
 
-
 ```
 
 The key files and directories are as follows:
 
 * The **root directory** contains some gradle files, a README, a LICENSE and a TRADEMARK statement
-* **clients** contains the source code for spring boot integration
+* **clients** contains the source code for Spring Boot integration
 * **config** contains log4j2 configs
 * **contracts-java** and **workflows-java** contain the source code for the example CorDapp written in Java
 * **contracts-kotlin** and **workflows-kotlin** contain the same source code, but written in Kotlin. CorDapps can be developed in either Java and Kotlin
@@ -250,15 +246,17 @@ The first step is to deploy the CorDapp to nodes running locally. To do this:
 ├── certificates
 ├── corda.jar              // The Corda node runtime
 ├── cordapps               // The node's CorDapps
-│   ├── corda-finance-contracts-4.4.jar
-│   ├── corda-finance-workflows-4.4.jar
-│   └── cordapp-example-0.1.jar
+│   ├── config
+│   ├── corda-example-contracts-0.1.jar
+│   └── corda-example-workflows-0.1.jar
+├── djvm
 ├── drivers
 ├── logs
 ├── network-parameters
 ├── node.conf              // The node's configuration file
 ├── nodeInfo-<HASH>        // The hash will be different each time you generate a node
-└── persistence.mv.db      // The node's database
+├── persistence.mv.db      // The node's database
+└── persistence.trace.db   // The node's database
 ```
 
 
@@ -282,7 +280,7 @@ Start a Spring Boot server for each node by opening a terminal/command prompt fo
 * Unix/Mac OSX: `./gradlew runPartyXServer`
 * Windows: `gradlew.bat runPartyXServer`
 
-Look for the "Started ServerKt in X seconds" message &mdash; don’t rely on the % indicator.
+Look for the `Started Server in X seconds` message &mdash; don’t rely on the % indicator.
 
 
 {{< warning >}}

--- a/content/en/docs/corda-os/4.4/tutorial-cordapp.md
+++ b/content/en/docs/corda-os/4.4/tutorial-cordapp.md
@@ -93,18 +93,15 @@ The `cordapp-example` folder is structured as follows:
 │   ├── build.gradle
 │   └── src
 │       └── main
-            ├── java
+│           ├── java
 │           │   └── com
 │           │       └── example
 │           │           └── server
-│           │               └── JavaClientRpc
-│           ├── kotlin
-│           │   └── com
-│           │       └── example
-│           │           └── server
-│           │               ├── MainController.kt
-│           │               ├── NodeRPCConnection.kt
-│           │               └── Server.kt
+│           │               ├── CONSTANTS.java
+│           │               ├── MainController.java
+│           │               ├── NodeRPCConnection.java
+│           │               └── Server.java
+│           │               
 │           └── resources
 │               ├── application.properties
 │               └── public
@@ -214,7 +211,7 @@ The `cordapp-example` folder is structured as follows:
 The key files and directories are as follows:
 
 * The **root directory** contains some gradle files, a README, a LICENSE and a TRADEMARK statement
-* **clients** contains the source code for spring boot integration
+* **clients** contains the source code for Spring Boot integration
 * **config** contains log4j2 configs
 * **contracts-java** and **workflows-java** contain the source code for the example CorDapp written in Java
 * **contracts-kotlin** and **workflows-kotlin** contain the same source code, but written in Kotlin. CorDapps can be developed in either Java and Kotlin
@@ -250,15 +247,17 @@ The first step is to deploy the CorDapp to nodes running locally. To do this:
 ├── certificates
 ├── corda.jar              // The Corda node runtime
 ├── cordapps               // The node's CorDapps
-│   ├── corda-finance-contracts-4.4.jar
-│   ├── corda-finance-workflows-4.4.jar
-│   └── cordapp-example-0.1.jar
+│   ├── config
+│   ├── corda-example-contracts-0.1.jar
+│   └── corda-example-workflows-0.1.jar
+├── djvm
 ├── drivers
 ├── logs
 ├── network-parameters
 ├── node.conf              // The node's configuration file
 ├── nodeInfo-<HASH>        // The hash will be different each time you generate a node
-└── persistence.mv.db      // The node's database
+├── persistence.mv.db      // The node's database
+└── persistence.trace.db   // The node's database
 ```
 
 
@@ -282,7 +281,7 @@ Start a Spring Boot server for each node by opening a terminal/command prompt fo
 * Unix/Mac OSX: `./gradlew runPartyXServer`
 * Windows: `gradlew.bat runPartyXServer`
 
-Look for the "Started ServerKt in X seconds" message &mdash; don’t rely on the % indicator.
+Look for the `Started Server in X seconds` message &mdash; don’t rely on the % indicator.
 
 
 {{< warning >}}

--- a/content/en/docs/corda-os/4.5/tutorial-cordapp.md
+++ b/content/en/docs/corda-os/4.5/tutorial-cordapp.md
@@ -90,18 +90,15 @@ The `cordapp-example` folder is structured as follows:
 │   ├── build.gradle
 │   └── src
 │       └── main
-            ├── java
+│           ├── java
 │           │   └── com
 │           │       └── example
 │           │           └── server
-│           │               └── JavaClientRpc
-│           ├── kotlin
-│           │   └── com
-│           │       └── example
-│           │           └── server
-│           │               ├── MainController.kt
-│           │               ├── NodeRPCConnection.kt
-│           │               └── Server.kt
+│           │               ├── CONSTANTS.java
+│           │               ├── MainController.java
+│           │               ├── NodeRPCConnection.java
+│           │               └── Server.java
+│           │               
 │           └── resources
 │               ├── application.properties
 │               └── public
@@ -205,13 +202,12 @@ The `cordapp-example` folder is structured as follows:
 ├── settings.gradle
 └── TRADEMARK
 
-
 ```
 
 The key files and directories are as follows:
 
 * The **root directory** contains some gradle files, a README, a LICENSE and a TRADEMARK statement
-* **clients** contains the source code for spring boot integration
+* **clients** contains the source code for Spring Boot integration
 * **config** contains log4j2 configs
 * **contracts-java** and **workflows-java** contain the source code for the example CorDapp written in Java
 * **contracts-kotlin** and **workflows-kotlin** contain the same source code, but written in Kotlin. CorDapps can be developed in either Java and Kotlin
@@ -247,15 +243,17 @@ The first step is to deploy the CorDapp to nodes running locally. To do this:
 ├── certificates
 ├── corda.jar              // The Corda node runtime
 ├── cordapps               // The node's CorDapps
-│   ├── corda-finance-contracts-4.4.jar
-│   ├── corda-finance-workflows-4.4.jar
-│   └── cordapp-example-0.1.jar
+│   ├── config
+│   ├── corda-example-contracts-0.1.jar
+│   └── corda-example-workflows-0.1.jar
+├── djvm
 ├── drivers
 ├── logs
 ├── network-parameters
 ├── node.conf              // The node's configuration file
 ├── nodeInfo-<HASH>        // The hash will be different each time you generate a node
-└── persistence.mv.db      // The node's database
+├── persistence.mv.db      // The node's database
+└── persistence.trace.db   // The node's database
 ```
 
 
@@ -279,7 +277,7 @@ Start a Spring Boot server for each node by opening a terminal/command prompt fo
 * Unix/Mac OSX: `./gradlew runPartyXServer`
 * Windows: `gradlew.bat runPartyXServer`
 
-Look for the "Started ServerKt in X seconds" message &mdash; don’t rely on the % indicator.
+Look for the `Started Server in X seconds` message &mdash; don’t rely on the % indicator.
 
 
 {{< warning >}}


### PR DESCRIPTION
Implemented edits for tutorial-cordapp.md for Corda OS 4.4/4.5 and Corda Enterprise 4.4/4.5:

1. Updated the Java server start message and changed the message to code format.
2. Updated the project structure diagram to reflect file structure in the new samples-java repo.
3. Updated the node structure diagram to reflect node structure in the Basic cordapp-example.