### PR TITLE
EG-1143 Redirect version-less urls to latest

### DIFF
--- a/prod/etc/nginx/conf.d/default.conf
+++ b/prod/etc/nginx/conf.d/default.conf
@@ -58,6 +58,12 @@ server {
     # After:   https://api.corda.net/api/corda-enterprise/4.2/html/api/kotlin/corda/net.corda.client.jackson/-jackson-support/-amount-serializer/index.html
     rewrite ^/releases/(.*)/api/kotlin/(.*)$  https://api.corda.net/api/corda-enterprise/$1/html/api/kotlin/$2;
 
+    # Version-less redirects.  TODO:  i18n versions
+    # Match any URLs that don't start with a number, i.e. no version
+    # has been specified, and redirect to the latest version(s)
+    rewrite ^(/docs/corda-enterprise)/([a-zA-Z_].*)$ $1/4.5/$2;
+    rewrite ^(/docs/corda-os)/([a-zA-Z_].*)$ $1/4.5/$2;
+    rewrite ^(/docs/cenm)/([a-zA-Z_].*)$ $1/1.3/$2;
 
     # proxy the PHP scripts to Apache listening on 127.0.0.1:80
     #


### PR DESCRIPTION
Please test locally:
```
make DOCKER_BUILD_ARGS="-e HUGO_BASEURL=\"http://localhost:8888\"" prod-docker-serve
```

and also deploy to staging and test there.

Any URL with out a version, in ent, os, cenm, will redirect to 4.5/4.5/1.3   *regardless of whether it exists*.

http://localhost:8888/docs/corda-enterprise/node-upgrade-notes.html

will go to 4.5

http://localhost:8888/docs/corda-enterprise/nonsense.html

will end up on the 404 page.
