### PR TITLE
[EG-1572/EG-2033] Blob inspector download here url

### DIFF
--- a/content/en/docs/corda-os/3.3/blob-inspector.md
+++ b/content/en/docs/corda-os/3.3/blob-inspector.md
@@ -21,7 +21,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It uses
 `JacksonSupport` to do this (see [JSON](json.md)).
 
-The latest version of the tool can be downloaded from [here](https://www.corda.net/downloads/).
+The tool is distributed as part of Corda OS 3.3 in the form of runnable `.jar.` file -corda-tools-blob-inspector-3.3-corda.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -81,4 +81,3 @@ net.corda.nodeapi.internal.SignedNodeInfo
 
 Notice the file is actually a serialised `SignedNodeInfo` object, which has a `raw` property of type `SerializedBytes<NodeInfo>`.
 This property is materialised into a `NodeInfo` and is output under the `deserialized` field.
-

--- a/content/en/docs/corda-os/3.4/blob-inspector.md
+++ b/content/en/docs/corda-os/3.4/blob-inspector.md
@@ -21,7 +21,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It uses
 `JacksonSupport` to do this (see [JSON](json.md)).
 
-The latest version of the tool can be downloaded from [here](https://www.corda.net/downloads/).
+The tool is distributed as part of Corda OS 3.4 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-3.4-corda.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -81,4 +81,3 @@ net.corda.nodeapi.internal.SignedNodeInfo
 
 Notice the file is actually a serialised `SignedNodeInfo` object, which has a `raw` property of type `SerializedBytes<NodeInfo>`.
 This property is materialised into a `NodeInfo` and is output under the `deserialized` field.
-

--- a/content/en/docs/corda-os/4.0/blob-inspector.md
+++ b/content/en/docs/corda-os/4.0/blob-inspector.md
@@ -21,7 +21,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 this issue by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It
 uses `JacksonSupport` to do this (see [JSON](json.md)).
 
-The tool can be downloaded from [here](https://corda.net/resources).
+The tool is distributed as part of Corda OS 4.0 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-4.0.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -141,4 +141,3 @@ never normally need to specify this. Possible values [BINARY, HEX, BASE64]. Defa
 ### Sub-commands
 
 `install-shell-extensions`: Install `blob-inspector` alias and auto completion for bash and zsh. See [Shell extensions for CLI Applications](cli-application-shell-extensions.md) for more info.
-

--- a/content/en/docs/corda-os/4.1/blob-inspector.md
+++ b/content/en/docs/corda-os/4.1/blob-inspector.md
@@ -21,7 +21,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 this issue by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It
 uses `JacksonSupport` to do this (see [JSON](json.md)).
 
-The tool can be downloaded from [here](https://corda.net/resources).
+The tool is distributed as part of Corda OS 4.1 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-4.1.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -141,4 +141,3 @@ never normally need to specify this. Possible values [BINARY, HEX, BASE64]. Defa
 ### Sub-commands
 
 `install-shell-extensions`: Install `blob-inspector` alias and auto completion for bash and zsh. See [Shell extensions for CLI Applications](cli-application-shell-extensions.md) for more info.
-

--- a/content/en/docs/corda-os/4.3/blob-inspector.md
+++ b/content/en/docs/corda-os/4.3/blob-inspector.md
@@ -21,7 +21,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 this issue by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It
 uses `JacksonSupport` to do this (see [JSON](json.md)).
 
-The tool can be downloaded from [here](https://corda.net/resources).
+The tool is distributed as part of Corda OS 4.3 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-4.3.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -153,4 +153,3 @@ never normally need to specify this. Possible values [BINARY, HEX, BASE64]. Defa
 ### Sub-commands
 
 `install-shell-extensions`: Install `blob-inspector` alias and auto completion for bash and zsh. See [Shell extensions for CLI Applications](cli-application-shell-extensions.md) for more info.
-

--- a/content/en/docs/corda-os/4.4/blob-inspector.md
+++ b/content/en/docs/corda-os/4.4/blob-inspector.md
@@ -26,7 +26,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 this issue by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It
 uses `JacksonSupport` to do this (see [JSON](json.md)).
 
-The tool can be downloaded from [here](https://corda.net/resources).
+The tool is distributed as part of Corda OS 4.4 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-4.4.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 

--- a/content/en/docs/corda-os/4.5/blob-inspector.md
+++ b/content/en/docs/corda-os/4.5/blob-inspector.md
@@ -23,7 +23,7 @@ disadvantage is the inability to view the contents in a human-friendly manner. T
 this issue by allowing the contents of a binary blob file (or URL end-point) to be output in either YAML or JSON. It
 uses `JacksonSupport` to do this (see [JSON](json.md)).
 
-The tool can be downloaded from [here](https://corda.net/resources).
+The tool is distributed as part of Corda OS 4.5 in the form of runnable `.jar.` file - `corda-tools-blob-inspector-4.5.jar`.
 
 To run simply pass in the file or URL as the first parameter:
 
@@ -155,4 +155,3 @@ never normally need to specify this. Possible values [BINARY, HEX, BASE64]. Defa
 ### Sub-commands
 
 `install-shell-extensions`: Install `blob-inspector` alias and auto completion for bash and zsh. See [Shell extensions for CLI Applications](cli-application-shell-extensions.md) for more info.
-


### PR DESCRIPTION
Replaced the broken hyperlink in OS 4.5 with a statement along the lines of “The tool is distributed as part of Corda OS 4.5 in the form of runnable .jar. file - corda-tools-blob-inspector-4.5.jar.”

Implemented fix in the following versions:

Corda 4.4
Corda 4.5
Corda 4.6
Corda 4.3
Corda 4.1
Corda 4.0
Corda 3.4
Corda 3.3