### PR TITLE
[EG-1572/EG-3379] Typo on the What is a CorDapp? page

### DIFF
--- a/content/en/docs/corda-enterprise/3.0/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/3.0/cordapp-overview.md
@@ -40,7 +40,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/3.1/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/3.1/cordapp-overview.md
@@ -40,7 +40,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/3.2/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/3.2/cordapp-overview.md
@@ -40,7 +40,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/3.3/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/3.3/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/4.0/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/4.0/cordapp-overview.md
@@ -54,7 +54,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:>
+* Three flows:
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/4.1/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/4.1/cordapp-overview.md
@@ -55,7 +55,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/4.2/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/4.2/cordapp-overview.md
@@ -55,7 +55,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-enterprise/4.3/cordapp-overview.md
+++ b/content/en/docs/corda-enterprise/4.3/cordapp-overview.md
@@ -54,7 +54,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:>
+* Three flows:
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/2.0/cordapp-overview.md
+++ b/content/en/docs/corda-os/2.0/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/3.0/cordapp-overview.md
+++ b/content/en/docs/corda-os/3.0/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/3.1/cordapp-overview.md
+++ b/content/en/docs/corda-os/3.1/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/3.2/cordapp-overview.md
+++ b/content/en/docs/corda-os/3.2/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/3.3/cordapp-overview.md
+++ b/content/en/docs/corda-os/3.3/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/3.4/cordapp-overview.md
+++ b/content/en/docs/corda-os/3.4/cordapp-overview.md
@@ -36,7 +36,7 @@ owner may choose to install the Bond Trading CorDapp, with the following compone
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/4.0/cordapp-overview.md
+++ b/content/en/docs/corda-os/4.0/cordapp-overview.md
@@ -55,7 +55,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/4.1/cordapp-overview.md
+++ b/content/en/docs/corda-os/4.1/cordapp-overview.md
@@ -55,7 +55,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:> 
+* Three flows: 
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/4.3/cordapp-overview.md
+++ b/content/en/docs/corda-os/4.3/cordapp-overview.md
@@ -54,7 +54,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:>
+* Three flows:
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/4.4/cordapp-overview.md
+++ b/content/en/docs/corda-os/4.4/cordapp-overview.md
@@ -60,7 +60,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:>
+* Three flows:
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger

--- a/content/en/docs/corda-os/4.5/cordapp-overview.md
+++ b/content/en/docs/corda-os/4.5/cordapp-overview.md
@@ -59,7 +59,7 @@ the following components:
 
 * A `BondState`, used to represent bonds as shared facts on the ledger
 * A `BondContract`, used to govern which ledger updates involving `BondState` states are valid
-* Three flows:>
+* Three flows:
 
     * An `IssueBondFlow`, allowing new `BondState` states to be issued onto the ledger
     * A `TradeBondFlow`, allowing existing `BondState` states to be bought and sold on the ledger


### PR DESCRIPTION
Removed incorrect carat symbol across 19 CE/OS versions.