### PR TITLE
[EG-1572/EG-3251] Typos on Node identity page

### DIFF
--- a/content/en/docs/corda-enterprise/3.0/node-structure.md
+++ b/content/en/docs/corda-enterprise/3.0/node-structure.md
@@ -77,13 +77,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -94,7 +94,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -102,13 +102,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -122,8 +122,7 @@ character confusability attacks
 
 ### External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/3.1/node-structure.md
+++ b/content/en/docs/corda-enterprise/3.1/node-structure.md
@@ -77,13 +77,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -94,7 +94,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -102,13 +102,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -122,8 +122,7 @@ character confusability attacks
 
 ### External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/3.2/node-structure.md
+++ b/content/en/docs/corda-enterprise/3.2/node-structure.md
@@ -77,13 +77,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -94,7 +94,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -102,13 +102,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -122,8 +122,7 @@ character confusability attacks
 
 ### External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/3.3/node-structure.md
+++ b/content/en/docs/corda-enterprise/3.3/node-structure.md
@@ -73,13 +73,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -90,7 +90,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -98,13 +98,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -118,8 +118,7 @@ character confusability attacks
 
 ### External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/4.0/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.0/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,8 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/4.1/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.1/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,8 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/4.2/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.2/node-naming.md
@@ -42,14 +42,14 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
 * The X.500 name can have no more than 128 characters across the six fields.
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -66,7 +66,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -81,8 +81,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-enterprise/4.3/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.3/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present>
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:>
+* The fields of the name have the following maximum character lengths:
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,7 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.

--- a/content/en/docs/corda-enterprise/4.4/node/setup/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.4/node/setup/node-naming.md
@@ -69,7 +69,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,`, `=`, `$`, `"`, `'`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
     * No leading or trailing whitespace
 
@@ -86,7 +86,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.

--- a/content/en/docs/corda-enterprise/4.5/node/setup/node-naming.md
+++ b/content/en/docs/corda-enterprise/4.5/node/setup/node-naming.md
@@ -65,7 +65,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,`, `=`, `$`, `"`, `'`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
     * No leading or trailing whitespace
 
@@ -82,7 +82,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.

--- a/content/en/docs/corda-os/2.0/deploying-a-node.md
+++ b/content/en/docs/corda-os/2.0/deploying-a-node.md
@@ -41,7 +41,7 @@ into the `plugins` folder.
 A node’s name must be a valid X500 name that obeys the following additional constraints:
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -53,7 +53,7 @@ A node’s name must be a valid X500 name that obeys the following additional co
 
 * The country code is a valid ISO 3166-1 two letter code in upper-case
 * The organisation, locality and country attributes are present
-* The organisation field of the name obeys the following constraints:> 
+* The organisation field of the name obeys the following constraints:
 
     * Has at least two letters
     * No leading or trailing whitespace
@@ -62,7 +62,7 @@ A node’s name must be a valid X500 name that obeys the following additional co
     * Does not contain the words “node” or “server”
     * Does not include the characters ‘,’ or ‘=’ or ‘$’ or ‘”’ or ‘’’ or ‘'
     * Is in NFKC normalization form
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
@@ -174,4 +174,3 @@ Windows) to run all the nodes at once. If you make any changes to your `deployNo
 the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/3.0/generating-a-node.md
+++ b/content/en/docs/corda-os/3.0/generating-a-node.md
@@ -62,13 +62,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -79,7 +79,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -87,13 +87,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -297,4 +297,3 @@ for testing and development purposes. If you make any changes to your CorDapp so
 need to re-run the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/3.1/generating-a-node.md
+++ b/content/en/docs/corda-os/3.1/generating-a-node.md
@@ -63,13 +63,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -80,7 +80,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -88,13 +88,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -298,4 +298,3 @@ for testing and development purposes. If you make any changes to your CorDapp so
 need to re-run the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/3.2/generating-a-node.md
+++ b/content/en/docs/corda-os/3.2/generating-a-node.md
@@ -63,13 +63,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -80,7 +80,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -88,13 +88,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -298,4 +298,3 @@ for testing and development purposes. If you make any changes to your CorDapp so
 need to re-run the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/3.3/generating-a-node.md
+++ b/content/en/docs/corda-os/3.3/generating-a-node.md
@@ -63,13 +63,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -80,7 +80,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -88,13 +88,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -298,4 +298,3 @@ for testing and development purposes. If you make any changes to your CorDapp so
 need to re-run the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/3.4/generating-a-node.md
+++ b/content/en/docs/corda-os/3.4/generating-a-node.md
@@ -63,13 +63,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -80,7 +80,7 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid ISO 3166-1 two letter code in upper-case
-* All attributes must obey the following constraints:> 
+* All attributes must obey the following constraints:
 
     * Upper-case first letter
     * Has at least two letters
@@ -88,13 +88,13 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `=` , `$` , `"` , `'` , `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
 
 
 
-* The `organisation` field of the name also obeys the following constraints:> 
+* The `organisation` field of the name also obeys the following constraints:
 
-    * No double-spacing> 
+    * No double-spacing
 
         * This is to avoid right-to-left issues, debugging issues when we can’t pronounce names over the phone, and
 character confusability attacks
@@ -298,4 +298,3 @@ for testing and development purposes. If you make any changes to your CorDapp so
 need to re-run the task to see the changes take effect.
 
 You can now run the nodes by following the instructions in [Running a node](running-a-node.md).
-

--- a/content/en/docs/corda-os/4.0/node-naming.md
+++ b/content/en/docs/corda-os/4.0/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,8 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-os/4.1/node-naming.md
+++ b/content/en/docs/corda-os/4.1/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,8 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-os/4.3/node-naming.md
+++ b/content/en/docs/corda-os/4.3/node-naming.md
@@ -42,13 +42,13 @@ present in the majority of names, but is an option for the cases which require i
 The name must also obey the following constraints:
 
 
-* The `organisation`, `locality` and `country` attributes are present> 
+* The `organisation`, `locality` and `country` attributes are present
 
     * The `state`, `organisational-unit` and `common name` attributes are optional
 
 
 
-* The fields of the name have the following maximum character lengths:> 
+* The fields of the name have the following maximum character lengths:  
 
     * Common name: 64
     * Organisation: 128
@@ -64,7 +64,7 @@ The name must also obey the following constraints:
     * Does not include the following characters: `,` , `"`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
 
 
@@ -79,8 +79,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-

--- a/content/en/docs/corda-os/4.4/node-naming.md
+++ b/content/en/docs/corda-os/4.4/node-naming.md
@@ -50,7 +50,7 @@ The name must also obey the following constraints:
 * The `organisation`, `locality` and `country` attributes are present
 * The `state`, `organisational-unit` and `common name` attributes are optional
 * The maximum number of characters in the whole x500 name string is 128 characters
-* The fields of the name have character lengths **less** than the following maximum values:>
+* The fields of the name have character lengths **less** than the following maximum values:
 
     * Common name: 64
     * Organisation: 128
@@ -61,19 +61,19 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case
-* The `organisation` field of the name obeys the following constraints:>
+* The `organisation` field of the name obeys the following constraints:
 
     * Has at least two letters
 
 
 
-* All data fields adhere to the following constraints:>
+* All data fields adhere to the following constraints:
 
     * Upper-case first letter
     * Does not include the following characters: `,`, `=`, `$`, `"`, `'`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
     * No leading or trailing whitespace
 
@@ -90,7 +90,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.

--- a/content/en/docs/corda-os/4.5/node-naming.md
+++ b/content/en/docs/corda-os/4.5/node-naming.md
@@ -47,7 +47,7 @@ The name must also obey the following constraints:
 * The `organisation`, `locality` and `country` attributes are present
 * The `state`, `organisational-unit` and `common name` attributes are optional
 * The maximum number of characters in the whole x500 name string is 128 characters
-* The fields of the name have character lengths **less** than the following maximum values:> 
+* The fields of the name have character lengths **less** than the following maximum values:
 
     * Common name: 64
     * Organisation: 128
@@ -58,19 +58,19 @@ The name must also obey the following constraints:
 
 
 * The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case
-* The `organisation` field of the name obeys the following constraints:> 
+* The `organisation` field of the name obeys the following constraints:
 
     * Has at least two letters
 
 
 
-* All data fields adhere to the following constraints:> 
+* All data fields adhere to the following constraints:
 
     * Upper-case first letter
     * Does not include the following characters: `,`, `=`, `$`, `"`, `'`, `\`
     * Is in NFKC normalization form
     * Does not contain the null character
-    * Only the latin, common and inherited unicode scripts are supported
+    * Only the Latin, common and inherited unicode scripts are supported
     * No double-spacing
     * No leading or trailing whitespace
 
@@ -87,8 +87,7 @@ The network operator of a Corda Network may put additional constraints on node n
 
 ## External identifiers
 
-Mappings to external identifiers such as Companies House nos., LEI, BIC, etc. should be stored in custom X.509
+Mappings to external identifiers such as Companies House numbers, LEI, BIC, etc. should be stored in custom X.509
 certificate extensions. These values may change for operational reasons, without the identity they’re associated with
 necessarily changing, and their inclusion in the distinguished name would cause significant logistical complications.
 The OID and format for these extensions will be described in a further specification.
-


### PR DESCRIPTION
Removed multiple instances of unwanted carat symbols across multiple docs versions.