### PR TITLE
[EG-1572/EG-3393] Update documentation for Vault Query API - missing Spring Data JPA examples

### DIFF
--- a/content/en/docs/corda-enterprise/3.0/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/3.0/api-vault-query.md
@@ -771,18 +771,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-enterprise/3.1/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/3.1/api-vault-query.md
@@ -771,18 +771,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-enterprise/3.2/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/3.2/api-vault-query.md
@@ -772,18 +772,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-enterprise/3.3/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/3.3/api-vault-query.md
@@ -838,18 +838,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-enterprise/4.0/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/4.0/api-vault-query.md
@@ -949,25 +949,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-enterprise/4.1/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/4.1/api-vault-query.md
@@ -949,25 +949,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-enterprise/4.2/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/4.2/api-vault-query.md
@@ -947,25 +947,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-enterprise/4.3/api-vault-query.md
+++ b/content/en/docs/corda-enterprise/4.3/api-vault-query.md
@@ -970,25 +970,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-os/3.0/api-vault-query.md
+++ b/content/en/docs/corda-os/3.0/api-vault-query.md
@@ -811,18 +811,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-os/3.1/api-vault-query.md
+++ b/content/en/docs/corda-os/3.1/api-vault-query.md
@@ -811,18 +811,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-os/3.2/api-vault-query.md
+++ b/content/en/docs/corda-os/3.2/api-vault-query.md
@@ -811,18 +811,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-os/3.3/api-vault-query.md
+++ b/content/en/docs/corda-os/3.3/api-vault-query.md
@@ -839,18 +839,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-os/3.4/api-vault-query.md
+++ b/content/en/docs/corda-os/3.4/api-vault-query.md
@@ -839,18 +839,9 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)

--- a/content/en/docs/corda-os/4.0/api-vault-query.md
+++ b/content/en/docs/corda-os/4.0/api-vault-query.md
@@ -948,7 +948,7 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of

--- a/content/en/docs/corda-os/4.0/api-vault-query.md
+++ b/content/en/docs/corda-os/4.0/api-vault-query.md
@@ -955,19 +955,6 @@ recommended that the CorDapp developer utilise one of the many proven frameworks
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
 
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
-
 
 ## Mapping owning keys to external IDs
 

--- a/content/en/docs/corda-os/4.1/api-vault-query.md
+++ b/content/en/docs/corda-os/4.1/api-vault-query.md
@@ -948,25 +948,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-os/4.3/api-vault-query.md
+++ b/content/en/docs/corda-os/4.3/api-vault-query.md
@@ -968,25 +968,12 @@ taking place in between and/or in parallel to paging requests. When using pagina
 `totalStatesAvailable` (from the `Vault.Page` result) and adjust further paging requests appropriately.
 
 
-## Other use case scenarios
+## Other use-case scenarios
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is
 recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of
 the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and
 Spring Data for advanced pagination and ordering constructs.
-
-The Corda Tutorials provide examples satisfying these additional Use Cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
 
 
 ## Mapping owning keys to external IDs

--- a/content/en/docs/corda-os/4.4/api-vault-query.md
+++ b/content/en/docs/corda-os/4.4/api-vault-query.md
@@ -969,19 +969,6 @@ If the results you were expecting do not match actual returned query results, we
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and Spring Data for advanced pagination and ordering constructs.
 
-The Corda tutorials provide examples satisfying these additional use cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
-
 
 ## Mapping owning keys to external IDs
 

--- a/content/en/docs/corda-os/4.5/api-vault-query.md
+++ b/content/en/docs/corda-os/4.5/api-vault-query.md
@@ -966,19 +966,6 @@ If the results you were expecting do not match actual returned query results, we
 
 For advanced use cases that require sophisticated pagination, sorting, grouping, and aggregation functions, it is recommended that the CorDapp developer utilise one of the many proven frameworks that ship with this capability out of the box, namely, implementations of JPQL (JPA Query Language) such as Hibernate for advanced SQL access, and Spring Data for advanced pagination and ordering constructs.
 
-The Corda tutorials provide examples satisfying these additional use cases:
-
-
-
-
-* Example CorDapp service using Vault API Custom Query to access attributes of IOU State
-* Example CorDapp service query extension executing Named Queries via [JPQL](http://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql)
-* [Advanced pagination](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html) queries using Spring Data [JPA](https://docs.spring.io/spring-data/jpa/docs/current/reference/html)
-
-
-
-
-
 
 ## Mapping owning keys to external IDs
 


### PR DESCRIPTION
Removed the reference to the Corda tutorials from all CE and OS versions, except CE4.4 and CE4.5, where the reference had already been removed.