### PR TITLE
[EG-1572/EG-2371] Documentation: Improve clarity of state example

### DIFF
--- a/content/en/docs/corda-enterprise/4.0/tutorial-contract.md
+++ b/content/en/docs/corda-enterprise/4.0/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -986,4 +986,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-enterprise/4.1/tutorial-contract.md
+++ b/content/en/docs/corda-enterprise/4.1/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -984,4 +984,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-enterprise/4.2/tutorial-contract.md
+++ b/content/en/docs/corda-enterprise/4.2/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -986,4 +986,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-enterprise/4.3/tutorial-contract.md
+++ b/content/en/docs/corda-enterprise/4.3/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 

--- a/content/en/docs/corda-os/4.0/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.0/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -984,4 +984,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-os/4.1/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.1/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -984,4 +984,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-os/4.3/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.3/tutorial-contract.md
@@ -198,7 +198,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -984,4 +984,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-

--- a/content/en/docs/corda-os/4.4/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.4/tutorial-contract.md
@@ -203,7 +203,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 

--- a/content/en/docs/corda-os/4.5/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.5/tutorial-contract.md
@@ -200,7 +200,7 @@ public class State implements OwnableState {
 
 {{< /tabs >}}
 
-We define a class that implements the `ContractState` interface.
+We define a class that indirectly implements the `ContractState` via `OwnableState`.
 
 We have four fields in our state:
 
@@ -986,4 +986,3 @@ the all future cash states stemming from this one.
 We will also consider marking states that are capable of being encumbrances as such. This will prevent states being used
 as encumbrances inadvertently. For example, the time-lock above would be usable as an encumbrance, but it makes no sense to
 be able to encumber a cash state with another one.
-


### PR DESCRIPTION
Updated sentence to clarify that `ContractState` is implemented indirectly via `OwnableState`.