### PR TITLE
[EG-1572/EG-3609] Re-name Developer Tutorials button to Corda Training

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -5,7 +5,7 @@ target_corda_os: /docs/corda-os/4.5/_index.md
 target_corda_enterprise: /docs/corda-enterprise/4.5/_index.md
 target_cenm: /docs/cenm/1.3/_index.md
 header: DOCUMENTATION & TRAINING FOR CORDA PLATFORM DEVELOPERS AND OPERATORS
-tagline: Use the docs to help develop Corda applications, run a network, and operate enterprise level tools for your business. New to Corda? Take the training and begin your journey to becoming a Corda blockchain specialist today.
+tagline: Use the docs to help develop Corda applications, run a network, and operate enterprise-level tools for your business. New to Corda? Take the training and begin your journey to becoming a Corda blockchain specialist today.
 summary: Use the docs to help develop Corda applications, run a network, and operate enterprise level tools for your business. New to Corda? Take the training and begin your journey to becoming a Corda blockchain specialist today.
 ---
 

--- a/themes/hugo-r3-theme/layouts/index.html
+++ b/themes/hugo-r3-theme/layouts/index.html
@@ -25,7 +25,7 @@
                             <span>Corda Enterprise Network Manager</span>
                         </a>
                         <a class="github" href="https://training.corda.net" target=new>
-                            <span>Corda Training</span>
+                            <span>Corda <br/> Training</span>
                         </a>
                     </div>
                 </div>

--- a/themes/hugo-r3-theme/layouts/index.html
+++ b/themes/hugo-r3-theme/layouts/index.html
@@ -25,7 +25,7 @@
                             <span>Corda Enterprise Network Manager</span>
                         </a>
                         <a class="github" href="https://training.corda.net" target=new>
-                            <span>Developer<br/>Tutorials</span>
+                            <span>Corda Training</span>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Re-named "Developer Tutorials" button on docs home page to "Corda Training".