### PR TITLE
[EG-1572/EG-3250] Broken links to tutorials on Debugging a CorDapp page

### DIFF
--- a/content/en/docs/corda-enterprise/4.0/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.0/debugging-a-cordapp.md
@@ -16,9 +16,7 @@ title: Debugging a CorDapp
 
 # Debugging a CorDapp
 
-
 There are several ways to debug your CorDapp.
-
 
 ## Using a `MockNetwork`
 
@@ -26,14 +24,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,59 +41,50 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
+* Attach the debugger to the node of interest on its debug port:
 
-* Attach the debugger to the node of interest on its debug port:> 
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
-See [Enabling remote debugging](running-a-node.md#enabling-remote-debugging).
-
+See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).

--- a/content/en/docs/corda-enterprise/4.1/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.1/debugging-a-cordapp.md
@@ -16,9 +16,7 @@ title: Debugging a CorDapp
 
 # Debugging a CorDapp
 
-
 There are several ways to debug your CorDapp.
-
 
 ## Using a `MockNetwork`
 
@@ -26,14 +24,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,59 +41,50 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
+* Attach the debugger to the node of interest on its debug port:
 
-* Attach the debugger to the node of interest on its debug port:> 
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).
-

--- a/content/en/docs/corda-enterprise/4.2/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.2/debugging-a-cordapp.md
@@ -16,9 +16,7 @@ title: Debugging a CorDapp
 
 # Debugging a CorDapp
 
-
 There are several ways to debug your CorDapp.
-
 
 ## Using a `MockNetwork`
 
@@ -26,14 +24,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,59 +41,50 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as described in [Integration Testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
+* Attach the debugger to the node of interest on its debug port:
 
-* Attach the debugger to the node of interest on its debug port:> 
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
-See [Enabling remote debugging](running-a-node.md#enabling-remote-debugging).
-
+See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).

--- a/content/en/docs/corda-enterprise/4.3/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.3/debugging-a-cordapp.md
@@ -16,9 +16,7 @@ title: Debugging a CorDapp
 
 # Debugging a CorDapp
 
-
 There are several ways to debug your CorDapp.
-
 
 ## Using a `MockNetwork`
 
@@ -26,14 +24,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)>
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,58 +41,50 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)>
+* Define a network using the node driver as described in [Integration Testing](../../corda-os/4.3/tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause>
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)>
-
+* Define a network using the node driver as described in [Integration Testing](../../corda-os/4.3/tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
+* Attach the debugger to the node of interest on its debug port:
 
-* Attach the debugger to the node of interest on its debug port:>
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause>
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
-See [Enabling remote debugging](running-a-node.md#enabling-remote-debugging).
+See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).

--- a/content/en/docs/corda-enterprise/4.4/cordapps/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.4/cordapps/debugging-a-cordapp.md
@@ -26,14 +26,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)>
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,56 +43,48 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per tutorial-integration-testing>
+* Define a network using the node driver as described in [Integration Testing](../../../corda-os/4.4/tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause>
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per tutorial-integration-testing>
-
+* Define a network using the node driver as described in [Integration Testing](../../../corda-os/4.4/tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
-
 * Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause>
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node

--- a/content/en/docs/corda-enterprise/4.5/cordapps/debugging-a-cordapp.md
+++ b/content/en/docs/corda-enterprise/4.5/cordapps/debugging-a-cordapp.md
@@ -22,14 +22,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)>
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -41,61 +39,50 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per tutorial-integration-testing>
+* Define a network using the node driver as described in [Integration Testing](../../../corda-os/4.5/tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause>
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per tutorial-integration-testing>
-
+* Define a network using the node driver as described in [Integration Testing](../../../corda-os/4.5/tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
     Starting out-of-process Node PartyA, debug port is 5008, jolokia monitoring port is not enabled {}
 ```
 
-
 * Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause>
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](../node/node-commandline.md#enabling-remote-debugging).
-
-
-

--- a/content/en/docs/corda-os/4.0/debugging-a-cordapp.md
+++ b/content/en/docs/corda-os/4.0/debugging-a-cordapp.md
@@ -26,14 +26,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,34 +43,30 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
@@ -80,24 +74,20 @@ For example:
 ```
 
 
-* Attach the debugger to the node of interest on its debug port:> 
+* Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).
-

--- a/content/en/docs/corda-os/4.1/debugging-a-cordapp.md
+++ b/content/en/docs/corda-os/4.1/debugging-a-cordapp.md
@@ -26,14 +26,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,34 +43,30 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
@@ -80,24 +74,20 @@ For example:
 ```
 
 
-* Attach the debugger to the node of interest on its debug port:> 
+* Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).
-

--- a/content/en/docs/corda-os/4.3/debugging-a-cordapp.md
+++ b/content/en/docs/corda-os/4.3/debugging-a-cordapp.md
@@ -26,14 +26,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -45,34 +43,30 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
@@ -80,24 +74,20 @@ For example:
 ```
 
 
-* Attach the debugger to the node of interest on its debug port:> 
+* Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).
-

--- a/content/en/docs/corda-os/4.4/debugging-a-cordapp.md
+++ b/content/en/docs/corda-os/4.4/debugging-a-cordapp.md
@@ -31,14 +31,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)>
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -50,34 +48,30 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)>
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause>
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)>
-
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
@@ -85,21 +79,18 @@ For example:
 ```
 
 
-* Attach the debugger to the node of interest on its debug port:>
+* Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause>
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node

--- a/content/en/docs/corda-os/4.5/debugging-a-cordapp.md
+++ b/content/en/docs/corda-os/4.5/debugging-a-cordapp.md
@@ -28,14 +28,12 @@ You can attach the [IntelliJ IDEA debugger](https://www.jetbrains.com/help/idea/
 `MockNetwork` to debug your CorDapp:
 
 
-* Define your flow tests as per [API: Testing](api-testing.md)> 
+* Define your flow tests as per [API: Testing](api-testing.md).
 
-    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`
+    * In your `MockNetwork`, ensure that `threadPerNode` is set to `false`.
 
-
-
-* Set your breakpoints
-* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause
+* Set your breakpoints.
+* Run the flow tests using the debugger. When the tests hit a breakpoint, execution will pause.
 
 
 ## Using the node driver
@@ -47,34 +45,30 @@ running via the node driver to debug your CorDapp.
 ### With the nodes in-process
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 
-* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`
+* In your `DriverParameters`, ensure that `startNodesInProcess` is set to `true`.
 
+* Run the driver using the debugger.
 
+* Set your breakpoints.
 
-* Run the driver using the debugger
-* Set your breakpoints
-* Interact with your nodes. When execution hits a breakpoint, execution will pause> 
+* Interact with your nodes. When execution hits a breakpoint, execution will pause.
 
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ### With remote debugging
 
 
-* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md)> 
-
+* Define a network using the node driver as per [Integration testing](tutorial-integration-testing.md).
 * In your `DriverParameters`, ensure that `startNodesInProcess` is set to `false` and `isDebug` is set to
-`true`
-
-
-
+`true`.
 * Run the driver. The remote debug ports for each node will be automatically generated and printed to the terminal.
-For example:
+
+  For example:
 
 ```none
 [INFO ] 11:39:55,471 [driver-pool-thread-0] (DriverDSLImpl.kt:814) internal.DriverDSLImpl.startOutOfProcessNode -
@@ -82,24 +76,20 @@ For example:
 ```
 
 
-* Attach the debugger to the node of interest on its debug port:> 
+* Attach the debugger to the node of interest on its debug port:
 
-* In IntelliJ IDEA, create a new run/debug configuration of type `Remote`
-* Set the run/debug configuration’s `Port` to the debug port
-* Start the run/debug configuration in debug mode
+  * In IntelliJ IDEA, create a new run/debug configuration of type `Remote`.
+  * Set the run/debug configuration’s `Port` to the debug port.
+  * Start the run/debug configuration in debug mode.
 
+* Set your breakpoints.
+* Interact with your node. When execution hits a breakpoint, execution will pause.
 
-
-* Set your breakpoints
-* Interact with your node. When execution hits a breakpoint, execution will pause> 
-
-* The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger
-
-
-
+{{< note >}}
+The nodes’ webservers always run in a separate process, and cannot be attached to by the debugger.
+{{< /note >}}
 
 
 ## By enabling remote debugging on a node
 
 See [Enabling remote debugging](node-commandline.md#enabling-remote-debugging).
-


### PR DESCRIPTION
Fixed links to tutorials.

Also, removed unwanted carat symbols, fixed indentation of steps, added note formats where appropriate, added punctuation.