### PR TITLE
ENT-5702: Updated command line usage

### DIFF
--- a/content/en/docs/corda-enterprise/4.5/node/node-commandline.md
+++ b/content/en/docs/corda-enterprise/4.5/node/node-commandline.md
@@ -28,6 +28,9 @@ The node can optionally be started with the following command-line options:
 * `--help`, `-h`: Show this help message and exit.
 * `--version`, `-V`: Print version information and exit.
 
+{{< warning >}}
+Ensure that the `[COMMAND]` precedes all options. Failing this, the provided arguments will not be in scope for the command and default arguments will be used instead as a result. For example, if `-f custom_config.conf` precedes the `[COMMAND]`, Corda will look for the default `node.conf` instead of the specified `custom_config.conf`.
+{{< /warning >}}
 
 ## Sub-commands
 

--- a/content/en/docs/corda-os/4.5/node-commandline.md
+++ b/content/en/docs/corda-os/4.5/node-commandline.md
@@ -33,6 +33,9 @@ The node can optionally be started with the following command-line options:
 * `--help`, `-h`: Show this help message and exit.
 * `--version`, `-V`: Print version information and exit.
 
+{{< warning >}}
+Ensure that the `[COMMAND]` precedes all options. Failing this, the provided arguments will not be in scope for the command and default arguments will be used instead as a result. For example, if `-f custom_config.conf` precedes the `[COMMAND]`, Corda will look for the default `node.conf` instead of the specified `custom_config.conf`.
+{{< /warning >}}
 
 ## Sub-commands
 
@@ -63,4 +66,3 @@ To enable remote debugging of the node, run the node with the following JVM argu
 `java -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" -jar corda.jar`
 
 This will allow you to attach a debugger to your node on port 5005.
-


### PR DESCRIPTION
Adds a warning alerting users to the unexpected behaviour that occurs when adding arguments before the command and how to mitigate this.