### PR TITLE
EG-3735: Fixes incorrect guidance on obtaining network trust root

### DIFF
--- a/content/en/docs/corda-enterprise/4.5/node/deploy/env-prod-test.md
+++ b/content/en/docs/corda-enterprise/4.5/node/deploy/env-prod-test.md
@@ -101,7 +101,7 @@ You can find examples of configuration files [available here](../corda-firewall-
 
 * Upload the appropriate `corda-<version>.jar` file to the Node root directory.
 * In the root of your Node directory, create a folder called `/certificates`.
-* The R3 Operations team will provide you with a `network-root-truststore.jks` which will be used for authentication.
+* The network operator will provide you with a `network-root-truststore.jks` which will be used for authentication during initial registration.
 * Upload the `network-root-truststore.jks` file to this directory.
 * In the root of your Node directory, create a folder called `cordapps`.  Upload your CorDapps to this folder.
 

--- a/content/en/docs/corda-enterprise/4.5/operations/deployment/env-prod-test.md
+++ b/content/en/docs/corda-enterprise/4.5/operations/deployment/env-prod-test.md
@@ -102,7 +102,7 @@ You can find examples of configuration files [available here](../../node/corda-f
 
 * Upload the appropriate `corda-<version>.jar` file to the Node root directory.
 * In the root of your Node directory, create a folder called `/certificates`.
-* The R3 Operations team will provide you with a `network-root-truststore.jks` which will be used for authentication.
+* The network operator will provide you with a `network-root-truststore.jks` which will be used for authentication during initial registration.
 * Upload the `network-root-truststore.jks` file to this directory.
 * In the root of your Node directory, create a folder called `cordapps`.  Upload your CorDapps to this folder.
 


### PR DESCRIPTION
Previously, the docs implied that the trust root should be obtained from R3, but this is only true in the case of the Corda Network.