### PR TITLE
EG-3884 Doc updates relating to querying COMPLETED, FAILED, and KILLED flows

### DIFF
--- a/content/en/docs/corda-enterprise/4.6/flow-start-with-client-id.md
+++ b/content/en/docs/corda-enterprise/4.6/flow-start-with-client-id.md
@@ -19,7 +19,12 @@ This feature enables you to make flow starts more reliable by relating a flow to
 
 You can use this feature to enable an RPC client to reconnect to an existing flow after a disconnect between the client and the node. This eliminates the need to write custom logic that allows you to check if a flow has already been invoked. Corda can then reliably handle this logic without custom code, so that node restarts or flow retries can be handled in a reliable manner.
 
-You can also enable an RPC client to signal to Corda to retain the flow's result or exception, so that it could be reclaimed at any time in the future.  
+You can also enable an RPC client to signal to Corda to retain the flow's result or exception, so that it could be reclaimed at any time in the future.
+
+{{< note >}}
+`COMPLETED`, `FAILED`, and `KILLED` flows can only be queried via the Multi RPC client when started by the `startFlowWithClientId` or `startFlowDynamicWithClientId` APIs described further below. For more information, see the [Interacting with a node](node/operating/clientrpc.md).
+{{< /note >}}
+
 
 ## Steps and examples
 

--- a/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
@@ -350,6 +350,10 @@ To interact with your node via any of the following interfaces, you need to buil
 All of these interfaces are located in the `:client:extensions-rpc` module.
 
 {{< note >}}
+`COMPLETED`, `FAILED`, and `KILLED` flows can only be queried when started by the `startFlowWithClientId` or `startFlowDynamicWithClientId` APIs using a unique, client-provided ID. For more information, see [Starting a flow with a client-provided unique ID](../../flow-start-with-client-id.md).
+{{< /note >}}
+
+{{< note >}}
 `CordaRPCClient` enables you to interact with the `CordaRPCOps` remote interface. However, if you intend to interact with any of the other remote interfaces that the Corda Enterprise provides, you need to build a client that uses the [MultiRPCClient](https://api.corda.net/api/corda-enterprise/4.6/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class.
 {{< /note >}}
 

--- a/content/en/docs/corda-enterprise/4.6/release-notes-enterprise.md
+++ b/content/en/docs/corda-enterprise/4.6/release-notes-enterprise.md
@@ -326,7 +326,7 @@ For more information, see [Node configuration reference](node/setup/corda-config
 
 Notary data stored in a Percona database can now be migrated to Cockroach DB.
 
-For more information, see [Upgrading a notary](notary/upgrading-a-notary.md).
+For more information, see [Importing Percona notary data to CockroachDB](notary/upgrading-a-notary.md).
 
 ### Notary identity configuration
 

--- a/content/en/docs/corda-enterprise/4.6/release-notes-enterprise.md
+++ b/content/en/docs/corda-enterprise/4.6/release-notes-enterprise.md
@@ -97,7 +97,7 @@ Node operators can now use the Multi RPC client to interact with a Corda Enterpr
 All of these interfaces are located in the `:client:extensions-rpc` module. Corda Enterprise customers can extend these interfaces to add custom, user-defined functionality to help manage their Corda Enterprise nodes.
 
 {{< note >}}
-`COMPLETED`, `FAILED` and `KILLED` flows can only be queried when started by the `startFlowWithClientId` or `startFlowDynamicWithClientId` APIs using [a unique client-provided ID](#ability-to-prevent-duplicate-flow-starts-and-retrieve-the-status-of-started-flows).
+`COMPLETED`, `FAILED`, and `KILLED` flows can only be queried when started by the `startFlowWithClientId` or `startFlowDynamicWithClientId` APIs using [a unique client-provided ID](#ability-to-prevent-duplicate-flow-starts-and-retrieve-the-status-of-started-flows).
 {{< /note >}}
 
 For more information, see the [Interacting with a node](node/operating/clientrpc.md) documentation section or see [MultiRPCClient](https://api.corda.net/api/corda-enterprise/4.6/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.


### PR DESCRIPTION
EG-3884 Doc updates for COMPLETED, FAILED, or KILLED flows will not be returned in the flow query unless they were started with a CLIENT ID