### PR TITLE
EG-4024 Fixed broken link on CE landing page + other fixes

### DIFF
--- a/content/en/docs/cenm/1.4/_index.md
+++ b/content/en/docs/cenm/1.4/_index.md
@@ -24,7 +24,7 @@ that are otherwise available from [Corda Network](https://corda.network), which 
 {{< note >}}
 **Release notes**
 
-* For all Corda Enterprise Network Manager release notes, see the [Corda Enterprise Network Manager release notes](release-notes.m) page.
+* For all Corda Enterprise Network Manager release notes, see the [Corda Enterprise Network Manager release notes](release-notes.md) page.
 * For the latest Corda Enterprise release notes, see the [Corda Enterprise 4.6 release notes](../../corda-enterprise/4.6/release-notes-enterprise.md) page. You can view release notes for previous versions of Corda Enterprise in the relevant documentation section for each version, accessible from the left-hand side menu.
 * For all Corda open source release notes, see the [Corda release notes](../../corda-os/4.6/release-notes.md) page.
 

--- a/content/en/docs/cenm/1.4/_index.md
+++ b/content/en/docs/cenm/1.4/_index.md
@@ -21,6 +21,15 @@ This is provided as an alternative to using the service-level-managed production
 that are otherwise available from [Corda Network](https://corda.network), which is governed by the independent
 [Corda Network Foundation](https://corda.network/).
 
+{{< note >}}
+**Release notes**
+
+* For all Corda Enterprise Network Manager release notes, see the [Corda Enterprise Network Manager release notes](release-notes.m) page.
+* For the latest Corda Enterprise release notes, see the [Corda Enterprise 4.6 release notes](../../corda-enterprise/4.6/release-notes-enterprise.md) page. You can view release notes for previous versions of Corda Enterprise in the relevant documentation section for each version, accessible from the left-hand side menu.
+* For all Corda open source release notes, see the [Corda release notes](../../corda-os/4.6/release-notes.md) page.
+
+{{< /note >}}
+
 The Corda Enterprise Network Manager provides three main services:
 
 * [Identity Manager Service](identity-manager.md) - enables nodes to join the network, and handles revocation of a node certificate.

--- a/content/en/docs/cenm/1.4/aws-deployment-guide.md
+++ b/content/en/docs/cenm/1.4/aws-deployment-guide.md
@@ -10,6 +10,8 @@ title: CENM Deployment on AWS
 weight: 22
 ---
 
+# CENM Deployment on AWS
+
 You can deploy CENM on AWS with PostgreSQL. Use the guides in this section to get started with CENM on AWS, create a new HSM, and set up a reference environment using AWS and PostgreSQL.
 
 * [Deploy CENM 1.4 in AWS with EKS](aws-deployment-eks)

--- a/content/en/docs/cenm/1.4/release-notes.md
+++ b/content/en/docs/cenm/1.4/release-notes.md
@@ -14,7 +14,7 @@ title: Release notes
 ---
 
 
-# Release notes
+# Corda Enterprise Network Manager release notes
 
 ## Corda Enterprise Network Manager 1.4
 

--- a/content/en/docs/cenm/1.4/signing-service.md
+++ b/content/en/docs/cenm/1.4/signing-service.md
@@ -1491,7 +1491,7 @@ public final class CSRResponse {
     public String getRequestId() {
         return requestId;
     }
-    
+
     /**
      * Constructs a response with CRL request status. with the specified data.
      *
@@ -1550,20 +1550,20 @@ public final class CRLResponse {
     */
     @Nonnull
     public final SigningStatus getStatus();
-    
+
     /**
     * Returns signed certificate revocation list (CRL).
     */
     @Nullable
     public final CRLSigningData getCrlSigningData();
-    
+
     /**
     * Returns the ID of the request. Might be null if the request is completed immediately and no ID is provided
     * for later use.
     */
     @Nullable
     public String getRequestId();
-    
+
     /**
     * Constructs a response with the specified status and signed CRL.
     *
@@ -1742,7 +1742,7 @@ public final class NetworkParametersResponse {
      */
     @Nullable
     public String getRequestId();
-    
+
     /**
      * Returns signed Network Parameters
      */
@@ -1810,7 +1810,7 @@ The Signing Service ships with example plug-ins.
 {{< note >}}
 Please note that these plug-ins should only be used as a base
 when developing plug-ins and they should never be used in a production environment.
-{{< note >}}
+{{< /note >}}
 
 Please refer to the `README` docs inside the source directories for each plug-in as they contain all the
 necessary information about the architecture and usage of those plug-ins.

--- a/content/en/docs/corda-enterprise/4.6/_index.md
+++ b/content/en/docs/corda-enterprise/4.6/_index.md
@@ -22,7 +22,13 @@ When one or more Nodes are involved in a transaction, the transaction must be no
 of Node that provides uniqueness consensus by attesting that, for a given transaction, it has not already signed other
 transactions that consumes any of the proposed transaction’s input states.
 
-For all Corda release notes, see the [Release Notes](release-notes-index.md) index page.
+{{< note >}}
+**Release notes**
+
+* For the latest Corda Enterprise release notes, see the [Corda Enterprise 4.6 release notes](release-notes-enterprise.md) page. You can view release notes for previous versions of Corda Enterprise in the relevant documentation section for each version, accessible from the left-hand side menu.
+* For all Corda open source release notes, see the [Corda release notes](../../corda-os/4.6/release-notes.md) page.
+* For all Corda Enterprise Network Manager release notes, see the [Corda Enterprise Network Manager release notes](../../cenm/1.4/release-notes.m) page.
+{{< /note >}}
 
 ## Corda Enterprise
 
@@ -43,7 +49,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Corda ledger|&#9745;|&#9745;|
 |Flow framework|&#9745;|&#9745;|
 |Immutable states|&#9745;|&#9745;|
@@ -62,7 +68,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Single node|&#9745;|&#9745;|
 |Multiple nodes for high availability/disaster recovery|&#9746;|&#9745;|
 
@@ -73,7 +79,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |In-process Artemis MQ|&#9745;|&#9745;|
 |External Artemis MQ|&#9746;|&#9745;|
 |Corda firewall|&#9746;|&#9745;|
@@ -86,7 +92,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Java keystore file|&#9745;|&#9745;|
 |HSM support|&#9746;|&#9745;|
 
@@ -97,7 +103,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |H2 (development use only)|&#9745;|&#9745;|
 |Postgres|&#9745; Please note that this has been harmonised with Corda Enterprise in Corda 4.5 to allow for in-place upgrades|&#9745;|
 |SQL Server|Experimental only|&#9745;|
@@ -110,7 +116,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Simple notary|&#9745;|&#9745;|
 |Oracle RAC connectivity|&#9746;|&#9745;|
 |CockroachDB connectivity|&#9746;|&#9745;|
@@ -123,7 +129,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Dynamic database caching and performance enhancements|&#9746;|&#9745;|
 |Multi-threaded flow state machine|&#9746;|&#9745;|
 
@@ -134,7 +140,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Node health check tool|&#9746;|&#9745;|
 |Configuration obfuscation tool|&#9746;|&#9745;|
 |HA admin tool|&#9746;|&#9745;|
@@ -146,7 +152,7 @@ More details on Corda Enterprise features compared to Corda open source features
 {{< table >}}
 
 |Feature|Corda open source|Corda Enterprise|
-|------------------------------------------------------------|------------------------------|------------------------------|
+|:------------------------------|:------------------------------|:------------------------------|
 |Developer mailing lists (no SLA)|&#9745;|&#9745;|
 |Cordaledger slack (no SLA)|&#9745;|&#9745;|
 |Software maintenance|&#9746;|&#9745;|

--- a/content/en/docs/corda-os/4.6/_index.md
+++ b/content/en/docs/corda-os/4.6/_index.md
@@ -27,4 +27,12 @@ audience. The [technical white paper](https://www.r3.com/white-papers/corda-tech
 **Questions or comments?** Get in touch on [Slack](https://slack.corda.net/) or ask a question on
 [Stack Overflow](https://stackoverflow.com/questions/tagged/corda).
 
+{{< note >}}
+**Release notes**
+
+* For all Corda open source release notes, see the [Corda release notes](release-notes.md) page.
+* For the latest Corda Enterprise release notes, see the [Corda Enterprise 4.6 release notes](../../corda-enterprise/4.6/release-notes-enterprise.md) page. You can view release notes for previous versions of Corda Enterprise in the relevant documentation section for each version, accessible from the left-hand side menu.
+* For all Corda Enterprise Network Manager release notes, see the [Corda Enterprise Network Manager release notes](../../cenm/1.4/release-notes.m) page.
+{{< /note >}}
+
 We look forward to seeing what you can do with Corda!

--- a/themes/hugo-r3-theme/layouts/index.html
+++ b/themes/hugo-r3-theme/layouts/index.html
@@ -599,6 +599,10 @@ a.button {
         Deployment with Docker, Kubernetes, and Helm
         charts</a></li>
 
+        <li><a href=
+        "docs/cenm/1.4/deployment-kubernetes.html">CENM
+        Deployment on AWS</a></li>
+
         <li><a href="docs/cenm/1.4/angel-service.html">Angel
         Service</a></li>
 
@@ -619,7 +623,7 @@ a.button {
         Service</a></li>
 
         <li><a href="docs/cenm/1.4/signing-service.html">Signing
-        and SMR Services</a></li>
+        Service</a></li>
 
         <li><a href="docs/cenm/1.4/zone-service.html">Zone
         Service</a></li>


### PR DESCRIPTION
* Fixed broken link on CE landing page.
* Added release notes sections to all landing pages.
* Fixed wrong SMR link on CENM tab in home page.
* Added missing AWS deployment guide link to CENM tab in the home page.
* Added title to AWS deployment guide index.
* Updated CENM RN title.