### PR TITLE
EG-4165 Update pre-4.6 OS & Ent New Relic licences

### DIFF
--- a/content/en/docs/corda-enterprise/4.2/legal-info.md
+++ b/content/en/docs/corda-enterprise/4.2/legal-info.md
@@ -100,11 +100,11 @@ This file is based on or incorporates material from the projects listed below (T
 * error_prone_annotations
 * forms
 * forms_rt
-* 
+*
 {{< warning >}}geronimojms_{{< /warning >}}
 
  2.0_spec
-* 
+*
 {{< warning >}}geronimojson_{{< /warning >}}
 
  1.0_spec
@@ -2274,7 +2274,7 @@ Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
-* Definitions.1.1. Contributor. means each individual or entity that creates or contributes to the creation of Modifications.1.2. Contributor Version. means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.1.3. Covered Software. means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.1.4. Executable. means the Covered Software in any form other than Source Code.1.5. Initial Developer. means the individual or entity that first makes Original Software available under this License.1.6. Larger Work. means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.1.7. License. means this document.1.8. Licensable. means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.1.9. Modifications. means the Source Code and Executable form of any of the following:> 
+* Definitions.1.1. Contributor. means each individual or entity that creates or contributes to the creation of Modifications.1.2. Contributor Version. means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.1.3. Covered Software. means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.1.4. Executable. means the Covered Software in any form other than Source Code.1.5. Initial Developer. means the individual or entity that first makes Original Software available under this License.1.6. Larger Work. means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.1.7. License. means this document.1.8. Licensable. means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.1.9. Modifications. means the Source Code and Executable form of any of the following:>
 
 * Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
 * Any new file that contains any part of the Original Software or previous Modification; or
@@ -2282,11 +2282,11 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 1.10. Original Software. means the Source Code and Executable form of computer software code that is originally released under this License.1.11. Patent Claims. means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.1.12. Source Code. means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.1.13. You. (or .Your.) means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, .You. includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, .control. means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
-* License Grants.> 
+* License Grants.>
 
-2.1. The Initial Developer Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:> 
-> 
-> 
+2.1. The Initial Developer Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:>
+>
+>
 > * under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
 > * under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
 
@@ -2297,7 +2297,7 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 
-2.2. Contributor Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:> 
+2.2. Contributor Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:>
 
 * under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
 * under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
@@ -2307,7 +2307,7 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 
-* Distribution Obligations.> 
+* Distribution Obligations.>
 3.1. Availability of Source Code.
 Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.3.2. Modifications.
 The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.3.3. Required Notices.
@@ -2316,14 +2316,14 @@ You may not offer or impose any terms on any Covered Software in Source Code for
 You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient.s rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.3.6. Larger Works.
 You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
 
-* Versions of the License.> 
+* Versions of the License.>
 4.1. New Versions.
 Sun Microsystems, Inc. is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.4.2. Effect of New Versions.
 You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.4.3. Modified Versions.
 When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
 
 * DISCLAIMER OF WARRANTY.COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN .AS IS. BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
-* TERMINATION.> 
+* TERMINATION.>
 6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as .Participant.) alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.6.3. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
 
 * LIMITATION OF LIABILITY.UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY.S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
@@ -2454,25 +2454,25 @@ If the program is interactive, make it output a short notice like this when it s
 
 
 Gnomovision version 69, Copyright (C) year name of author
-Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type 
+Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
 {{< warning >}}`{{< /warning >}}
 
-show w’. This is free software, and you are welcome to redistribute it under certain conditions; type 
+show w’. This is free software, and you are welcome to redistribute it under certain conditions; type
 {{< warning >}}`{{< /warning >}}
 
 show c’ for details.
 
 
-The hypothetical commands 
+The hypothetical commands
 {{< warning >}}`{{< /warning >}}
 
-show w’ and 
+show w’ and
 {{< warning >}}`{{< /warning >}}
 
-show c’ should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than 
+show c’ should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than
 {{< warning >}}`{{< /warning >}}
 
-show w’ and 
+show w’ and
 {{< warning >}}`{{< /warning >}}
 
 show c’; they could even be mouse-clicks or menu items–whatever suits your program.
@@ -2480,7 +2480,7 @@ show c’; they could even be mouse-clicks or menu items–whatever suits your p
 You should also get your employer (if you work as a programmer) or your school, if any, to sign a “copyright disclaimer” for the program, if necessary. Here is a sample; alter the names:
 
 
-Yoyodyne, Inc., hereby disclaims all copyright interest in the program 
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
 {{< warning >}}`{{< /warning >}}
 
 Gnomovision’ (which makes passes at compilers) written by James Hacker.
@@ -3941,52 +3941,24 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
-newrelic-api    3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
-[https://newrelic.com/](https://newrelic.com/)
-[https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license](https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license)
+newrelic-api	3.10.0
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
+https://newrelic.com/
 
-———————–START OF LICENSE TEXT———————————–
+-----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
-———————END OF LICENSE TEXT—————————————–
+---------------------END OF LICENSE TEXT-----------------------------------------
 
 =============END OF NOTICES AND INFORMATION for above components=================
 
@@ -4082,4 +4054,3 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ———————-END OF OPEN SOURCE LICENSES ———————–
-

--- a/content/en/docs/corda-enterprise/4.3/legal-info.md
+++ b/content/en/docs/corda-enterprise/4.3/legal-info.md
@@ -3941,52 +3941,24 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
-newrelic-api    3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
-[https://newrelic.com/](https://newrelic.com/)
-[https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license](https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license)
+newrelic-api	3.10.0
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
+https://newrelic.com/
 
-———————–START OF LICENSE TEXT———————————–
+-----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
-———————END OF LICENSE TEXT—————————————–
+---------------------END OF LICENSE TEXT-----------------------------------------
 
 =============END OF NOTICES AND INFORMATION for above components=================
 

--- a/content/en/docs/corda-enterprise/4.4/legal-info.md
+++ b/content/en/docs/corda-enterprise/4.4/legal-info.md
@@ -144,51 +144,52 @@ This file is based on or incorporates material from the projects listed below (T
 124.	metrics-core
 125.	metrics-graphite
 126.	metrics-jmx
-127.	mina-core
-128.	minlog
-129.	netty
-130.	netty-buffer
-131.	netty-codec
-132.	netty-codec-http
-133.	netty-codec-socks
-134.	netty-common
-135.	netty-handler
-136.	netty-handler-proxy
-137.	netty-resolver
-138.	netty-tcnative-boringssl-static
-139.	netty-transport
-140.	netty-transport-native-epoll
-141.	netty-transport-native-kqueue
-142.	netty-transport-native-unix-common
-143.	newrelic-api
-144.	objenesis
-145.	okhttp
-146.	okio
-147.	gant_groovy1.8
-148.	gwtbootstrap3
-149.	picocli
-150.	proton-j
-151.	quasar-core
-152.	reflectasm
-153.	rxjava
-154.	shiro-cache
-155.	shiro-config-core
-156.	shiro-config-ogdl
-157.	shiro-core
-158.	shiro-crypto-cipher
-159.	shiro-crypto-core
-160.	shiro-crypto-hash
-161.	shiro-event
-162.	shiro-lang
-163.	slf4j-api
-164.	slf4j-nop
-165.	snakeyaml
-166.	snappy
-167.	sshd-core
-168.	sshd-pam
-169.	stax-ex
-170.	txw2
-171.	zookeeper
+127.	metrics-new-relic
+128.	mina-core
+129.	minlog
+130.	netty
+131.	netty-buffer
+132.	netty-codec
+133.	netty-codec-http
+134.	netty-codec-socks
+135.	netty-common
+136.	netty-handler
+137.	netty-handler-proxy
+138.	netty-resolver
+139.	netty-tcnative-boringssl-static
+140.	netty-transport
+141.	netty-transport-native-epoll
+142.	netty-transport-native-kqueue
+143.	netty-transport-native-unix-common
+144.	newrelic-api
+145.	objenesis
+146.	okhttp
+147.	okio
+148.	gant_groovy1.8
+149.	gwtbootstrap3
+150.	picocli
+151.	proton-j
+152.	quasar-core
+153.	reflectasm
+154.	rxjava
+155.	shiro-cache
+156.	shiro-config-core
+157.	shiro-config-ogdl
+158.	shiro-core
+159.	shiro-crypto-cipher
+160.	shiro-crypto-core
+161.	shiro-crypto-hash
+162.	shiro-event
+163.	shiro-lang
+164.	slf4j-api
+165.	slf4j-nop
+166.	snakeyaml
+167.	snappy
+168.	sshd-core
+169.	sshd-pam
+170.	stax-ex
+171.	txw2
+172.	zookeeper
 
 ## Start of Notices
 ===================== START OF NOTICES AND INFORMATION for the following components =====================
@@ -3071,6 +3072,64 @@ from your version.
 
 ================================================
 
+
+=========== START OF NOTICES AND INFORMATION for the following components=========
+
+metrics-new-relic       1.1.1
+[https://github.com/palominolabs/metrics-new-relic](https://github.com/palominolabs/metrics-new-relic)
+[https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE](https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE)
+
+-----------------------START OF LICENSE TEXT-----------------------------------
+
+# Copyfree Open Innovation License
+
+This is version 0.4 of the Copyfree Open Innovation License.
+
+## Terms and Conditions
+
+Redistributions, modified or unmodified, in whole or in part, must retain
+applicable copyright or other legal privilege notices, these conditions, and
+the following license terms and disclaimer.  Subject to these conditions, the
+holder(s) of copyright or other legal privileges, author(s) or assembler(s),
+and contributors of this work hereby grant to any person who obtains a copy of
+this work in any form:
+
+1. Permission to reproduce, modify, distribute, publish, sell, sublicense, use,
+and/or otherwise deal in the licensed material without restriction.
+
+2. A perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to reproduce, modify, distribute, publish, sell, use, and/or otherwise
+deal in the licensed material without restriction, for any and all patents:
+
+
+a. Held presently or in the future by each such holder of copyright or
+other legal privilege, author or assembler, or contributor, necessarily
+infringed by the contributions alone or by combination with the work, of
+that privilege holder, author or assembler, or contributor.
+
+b. Necessarily infringed by the work at the time that holder of copyright
+or other privilege, author or assembler, or contributor made any
+contribution to the work.
+
+
+NO WARRANTY OF ANY KIND IS IMPLIED BY, OR SHOULD BE INFERRED FROM, THIS LICENSE
+OR THE ACT OF DISTRIBUTION UNDER THE TERMS OF THIS LICENSE, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS, ASSEMBLERS, OR HOLDERS OF
+COPYRIGHT OR OTHER LEGAL PRIVILEGE BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY, WHETHER IN ACTION OF CONTRACT, TORT, OR OTHERWISE ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OF OR OTHER DEALINGS IN THE WORK.
+
+---------------------END OF LICENSE TEXT-----------------------------------------
+
+=============END OF NOTICES AND INFORMATION for above components=================
+
+
+================================================
+
+================================================
+
+
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
 quasar-core 0.7.10
@@ -4417,49 +4476,21 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
 newrelic-api	3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 https://newrelic.com/
-https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license
 
 -----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
 ---------------------END OF LICENSE TEXT-----------------------------------------
 

--- a/content/en/docs/corda-enterprise/4.5/legal-info.md
+++ b/content/en/docs/corda-enterprise/4.5/legal-info.md
@@ -141,50 +141,51 @@ This file is based on or incorporates material from the projects listed below (T
 123.	metrics-core
 124.	metrics-graphite
 125.	metrics-jmx
-126.	mina-core
-127.	minlog
-128.	netty
-129.	netty-buffer
-130.	netty-codec
-131.	netty-codec-http
-132.	netty-codec-socks
-133.	netty-common
-134.	netty-handler
-135.	netty-handler-proxy
-136.	netty-resolver
-137.	netty-tcnative-boringssl-static
-138.	netty-transport
-139.	netty-transport-native-epoll
-140.	netty-transport-native-kqueue
-141.	netty-transport-native-unix-common
-142.	newrelic-api
-143.	objenesis
-144.	okhttp
-145.	okio
-146.	picocli
-147.	proton-j
-148.	quasar-core
-149.	reflectasm
-150.	rxjava
-151.	shiro-cache
-152.	shiro-config-core
-153.	shiro-config-ogdl
-154.	shiro-core
-155.	shiro-crypto-cipher
-156.	shiro-crypto-core
-157.	shiro-crypto-hash
-158.	shiro-event
-159.	shiro-lang
-160.	slf4j-api
-161.	slf4j-nop
-162.	snakeyaml
-163.	snappy
-164.	sshd-common
-165.	sshd-core
-166.	sshd-pam
-167.	stax-ex
-168.	txw2
-169.	zookeeper
+126.	metrics-new-relic
+127.	mina-core
+128.	minlog
+129.	netty
+130.	netty-buffer
+131.	netty-codec
+132.	netty-codec-http
+133.	netty-codec-socks
+134.	netty-common
+135.	netty-handler
+136.	netty-handler-proxy
+137.	netty-resolver
+138.	netty-tcnative-boringssl-static
+139.	netty-transport
+140.	netty-transport-native-epoll
+141.	netty-transport-native-kqueue
+142.	netty-transport-native-unix-common
+143.	newrelic-api
+144.	objenesis
+145.	okhttp
+146.	okio
+147.	picocli
+148.	proton-j
+149.	quasar-core
+150.	reflectasm
+151.	rxjava
+152.	shiro-cache
+153.	shiro-config-core
+154.	shiro-config-ogdl
+155.	shiro-core
+156.	shiro-crypto-cipher
+157.	shiro-crypto-core
+158.	shiro-crypto-hash
+159.	shiro-event
+160.	shiro-lang
+161.	slf4j-api
+162.	slf4j-nop
+163.	snakeyaml
+164.	snappy
+165.	sshd-common
+166.	sshd-core
+167.	sshd-pam
+168.	stax-ex
+169.	txw2
+170.	zookeeper
 
 ## Start of Notices
 ===================== START OF NOTICES AND INFORMATION for the following components =====================
@@ -3052,6 +3053,64 @@ from your version.
 
 ================================================
 
+
+=========== START OF NOTICES AND INFORMATION for the following components=========
+
+metrics-new-relic       1.1.1
+[https://github.com/palominolabs/metrics-new-relic](https://github.com/palominolabs/metrics-new-relic)
+[https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE](https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE)
+
+-----------------------START OF LICENSE TEXT-----------------------------------
+
+# Copyfree Open Innovation License
+
+This is version 0.4 of the Copyfree Open Innovation License.
+
+## Terms and Conditions
+
+Redistributions, modified or unmodified, in whole or in part, must retain
+applicable copyright or other legal privilege notices, these conditions, and
+the following license terms and disclaimer.  Subject to these conditions, the
+holder(s) of copyright or other legal privileges, author(s) or assembler(s),
+and contributors of this work hereby grant to any person who obtains a copy of
+this work in any form:
+
+1. Permission to reproduce, modify, distribute, publish, sell, sublicense, use,
+and/or otherwise deal in the licensed material without restriction.
+
+2. A perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to reproduce, modify, distribute, publish, sell, use, and/or otherwise
+deal in the licensed material without restriction, for any and all patents:
+
+
+a. Held presently or in the future by each such holder of copyright or
+other legal privilege, author or assembler, or contributor, necessarily
+infringed by the contributions alone or by combination with the work, of
+that privilege holder, author or assembler, or contributor.
+
+b. Necessarily infringed by the work at the time that holder of copyright
+or other privilege, author or assembler, or contributor made any
+contribution to the work.
+
+
+NO WARRANTY OF ANY KIND IS IMPLIED BY, OR SHOULD BE INFERRED FROM, THIS LICENSE
+OR THE ACT OF DISTRIBUTION UNDER THE TERMS OF THIS LICENSE, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS, ASSEMBLERS, OR HOLDERS OF
+COPYRIGHT OR OTHER LEGAL PRIVILEGE BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY, WHETHER IN ACTION OF CONTRACT, TORT, OR OTHERWISE ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OF OR OTHER DEALINGS IN THE WORK.
+
+---------------------END OF LICENSE TEXT-----------------------------------------
+
+=============END OF NOTICES AND INFORMATION for above components=================
+
+
+================================================
+
+================================================
+
+
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
 quasar-core 0.7.10
@@ -4403,49 +4462,21 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
 newrelic-api	3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 https://newrelic.com/
-https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license
 
 -----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
 ---------------------END OF LICENSE TEXT-----------------------------------------
 

--- a/content/en/docs/corda-os/4.3/legal-info.md
+++ b/content/en/docs/corda-os/4.3/legal-info.md
@@ -80,11 +80,11 @@ This file is based on or incorporates material from the projects listed below (T
 * error_prone_annotations
 * forms
 * forms_rt
-* 
+*
 {{< warning >}}geronimojms_{{< /warning >}}
 
  2.0_spec
-* 
+*
 {{< warning >}}geronimojson_{{< /warning >}}
 
  1.0_spec
@@ -1067,7 +1067,7 @@ defend, and hold each Contributor harmless for any liability
 incurred by, or claims asserted against, such Contributor by reason
 of your accepting any such warranty or additional liability.
 
-END OF TERMS AND CONDITIONSAPPENDIX: How to apply the Apache License to your work.> 
+END OF TERMS AND CONDITIONSAPPENDIX: How to apply the Apache License to your work.>
 To apply the Apache License to your work, attach the following
 boilerplate notice, with the fields enclosed by brackets “[]”
 replaced with your own identifying information. (Don’t include
@@ -1078,7 +1078,7 @@ same “printed page” as the copyright notice for easier
 identification within third-party archives.
 Copyright [yyyy] [name of copyright owner]Licensed under the Apache License, Version 2.0 (the “License”);
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at> 
+You may obtain a copy of the License at>
 [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an “AS IS” BASIS,
@@ -2001,7 +2001,7 @@ Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
-* Definitions.1.1. Contributor. means each individual or entity that creates or contributes to the creation of Modifications.1.2. Contributor Version. means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.1.3. Covered Software. means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.1.4. Executable. means the Covered Software in any form other than Source Code.1.5. Initial Developer. means the individual or entity that first makes Original Software available under this License.1.6. Larger Work. means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.1.7. License. means this document.1.8. Licensable. means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.1.9. Modifications. means the Source Code and Executable form of any of the following:> 
+* Definitions.1.1. Contributor. means each individual or entity that creates or contributes to the creation of Modifications.1.2. Contributor Version. means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.1.3. Covered Software. means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.1.4. Executable. means the Covered Software in any form other than Source Code.1.5. Initial Developer. means the individual or entity that first makes Original Software available under this License.1.6. Larger Work. means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.1.7. License. means this document.1.8. Licensable. means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.1.9. Modifications. means the Source Code and Executable form of any of the following:>
 
 * Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
 * Any new file that contains any part of the Original Software or previous Modification; or
@@ -2009,9 +2009,9 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 1.10. Original Software. means the Source Code and Executable form of computer software code that is originally released under this License.1.11. Patent Claims. means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.1.12. Source Code. means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.1.13. You. (or .Your.) means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, .You. includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, .control. means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
-* License Grants.> 
+* License Grants.>
 
-2.1. The Initial Developer Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:> 
+2.1. The Initial Developer Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:>
 
 
 * under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
@@ -2024,7 +2024,7 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 
-2.2. Contributor Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:> 
+2.2. Contributor Grant.Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:>
 
 * under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
 * under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
@@ -2034,7 +2034,7 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 
 
 
-* Distribution Obligations.> 
+* Distribution Obligations.>
 3.1. Availability of Source Code.
 Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.3.2. Modifications.
 The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.3.3. Required Notices.
@@ -2043,14 +2043,14 @@ You may not offer or impose any terms on any Covered Software in Source Code for
 You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient.s rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.3.6. Larger Works.
 You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
 
-* Versions of the License.> 
+* Versions of the License.>
 4.1. New Versions.
 Sun Microsystems, Inc. is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.4.2. Effect of New Versions.
 You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.4.3. Modified Versions.
 When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
 
 * DISCLAIMER OF WARRANTY.COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN .AS IS. BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
-* TERMINATION.> 
+* TERMINATION.>
 6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as .Participant.) alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.6.3. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
 
 * LIMITATION OF LIABILITY.UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY.S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
@@ -2181,25 +2181,25 @@ If the program is interactive, make it output a short notice like this when it s
 
 
 Gnomovision version 69, Copyright (C) year name of author
-Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type 
+Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
 {{< warning >}}`{{< /warning >}}
 
-show w’. This is free software, and you are welcome to redistribute it under certain conditions; type 
+show w’. This is free software, and you are welcome to redistribute it under certain conditions; type
 {{< warning >}}`{{< /warning >}}
 
 show c’ for details.
 
 
-The hypothetical commands 
+The hypothetical commands
 {{< warning >}}`{{< /warning >}}
 
-show w’ and 
+show w’ and
 {{< warning >}}`{{< /warning >}}
 
-show c’ should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than 
+show c’ should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than
 {{< warning >}}`{{< /warning >}}
 
-show w’ and 
+show w’ and
 {{< warning >}}`{{< /warning >}}
 
 show c’; they could even be mouse-clicks or menu items–whatever suits your program.
@@ -2207,7 +2207,7 @@ show c’; they could even be mouse-clicks or menu items–whatever suits your p
 You should also get your employer (if you work as a programmer) or your school, if any, to sign a “copyright disclaimer” for the program, if necessary. Here is a sample; alter the names:
 
 
-Yoyodyne, Inc., hereby disclaims all copyright interest in the program 
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
 {{< warning >}}`{{< /warning >}}
 
 Gnomovision’ (which makes passes at compilers) written by James Hacker.
@@ -3644,52 +3644,24 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
-newrelic-api    3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
+newrelic-api  3.10.0
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 [https://newrelic.com/](https://newrelic.com/)
-[https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license](https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license)
 
-———————–START OF LICENSE TEXT———————————–
+-----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
-———————END OF LICENSE TEXT—————————————–
+---------------------END OF LICENSE TEXT-----------------------------------------
 
 =============END OF NOTICES AND INFORMATION for above components=================
 
@@ -3750,4 +3722,3 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ———————-END OF OPEN SOURCE LICENSES ———————–
-

--- a/content/en/docs/corda-os/4.4/legal-info.md
+++ b/content/en/docs/corda-os/4.4/legal-info.md
@@ -144,45 +144,46 @@ This file is based on or incorporates material from the projects listed below (T
 119.	metrics-core
 120.	metrics-jmx
 121.	mina-core
-122.	minlog
-123.	netty-buffer
-124.	netty-codec
-125.	netty-codec-http
-126.	netty-common
-127.	netty-handler
-128.	netty-resolver
-129.	netty-tcnative-boringssl-static
-130.	netty-transport
-131.	netty-transport-native-epoll
-132.	netty-transport-native-kqueue
-133.	netty-transport-native-unix-common
-134.	newrelic-api
-135.	objenesis
-136.	okhttp
-137.	okio
-138.	picocli
-139.	proton-j
-140.	quasar-core
-141.	reflectasm
-142.	rxjava
-143.	shiro-cache
-144.	shiro-config-core
-145.	shiro-config-ogdl
-146.	shiro-core
-147.	shiro-crypto-cipher
-148.	shiro-crypto-core
-149.	shiro-crypto-hash
-150.	shiro-event
-151.	shiro-lang
-152.	slf4j-api
-153.	slf4j-nop
-154.	snakeyaml
-155.	snappy
-156.	sshd-common
-157.	sshd-core
-158.	sshd-pam
-159.	stay-ex
-160.	txw2
+122.	metrics-new-relic
+123.	minlog
+124.	netty-buffer
+125.	netty-codec
+126.	netty-codec-http
+127.	netty-common
+128.	netty-handler
+129.	netty-resolver
+130.	netty-tcnative-boringssl-static
+131.	netty-transport
+132.	netty-transport-native-epoll
+133.	netty-transport-native-kqueue
+134.	netty-transport-native-unix-common
+135.	newrelic-api
+136.	objenesis
+137.	okhttp
+138.	okio
+139.	picocli
+140.	proton-j
+141.	quasar-core
+142.	reflectasm
+143.	rxjava
+144.	shiro-cache
+145.	shiro-config-core
+146.	shiro-config-ogdl
+147.	shiro-core
+148.	shiro-crypto-cipher
+149.	shiro-crypto-core
+150.	shiro-crypto-hash
+151.	shiro-event
+152.	shiro-lang
+153.	slf4j-api
+154.	slf4j-nop
+155.	snakeyaml
+156.	snappy
+157.	sshd-common
+158.	sshd-core
+159.	sshd-pam
+160.	stay-ex
+161.	txw2
 
 
 ## Start of Notices
@@ -3855,6 +3856,63 @@ from your version.
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
+metrics-new-relic       1.1.1
+[https://github.com/palominolabs/metrics-new-relic](https://github.com/palominolabs/metrics-new-relic)
+[https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE](https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE)
+
+———————–START OF LICENSE TEXT———————————–
+
+# Copyfree Open Innovation License
+
+This is version 0.4 of the Copyfree Open Innovation License.
+
+## Terms and Conditions
+
+Redistributions, modified or unmodified, in whole or in part, must retain
+applicable copyright or other legal privilege notices, these conditions, and
+the following license terms and disclaimer.  Subject to these conditions, the
+holder(s) of copyright or other legal privileges, author(s) or assembler(s),
+and contributors of this work hereby grant to any person who obtains a copy of
+this work in any form:
+
+1. Permission to reproduce, modify, distribute, publish, sell, sublicense, use,
+and/or otherwise deal in the licensed material without restriction.
+
+2. A perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to reproduce, modify, distribute, publish, sell, use, and/or otherwise
+deal in the licensed material without restriction, for any and all patents:
+
+
+a. Held presently or in the future by each such holder of copyright or
+other legal privilege, author or assembler, or contributor, necessarily
+infringed by the contributions alone or by combination with the work, of
+that privilege holder, author or assembler, or contributor.
+
+b. Necessarily infringed by the work at the time that holder of copyright
+or other privilege, author or assembler, or contributor made any
+contribution to the work.
+
+
+NO WARRANTY OF ANY KIND IS IMPLIED BY, OR SHOULD BE INFERRED FROM, THIS LICENSE
+OR THE ACT OF DISTRIBUTION UNDER THE TERMS OF THIS LICENSE, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS, ASSEMBLERS, OR HOLDERS OF
+COPYRIGHT OR OTHER LEGAL PRIVILEGE BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY, WHETHER IN ACTION OF CONTRACT, TORT, OR OTHERWISE ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OF OR OTHER DEALINGS IN THE WORK.
+
+———————END OF LICENSE TEXT—————————————–
+
+=============END OF NOTICES AND INFORMATION for above components=================
+
+
+================================================
+
+================================================
+
+
+=========== START OF NOTICES AND INFORMATION for the following components=========
+
 quasar-core 0.7.10
 Copyright (c) 2013-2018, Parallel Universe Software Co.
 http://docs.paralleluniverse.co/quasar/
@@ -5197,50 +5255,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
-newrelic-api	3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
-https://newrelic.com/
-https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license
+newrelic-api  3.10.0
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
+[https://newrelic.com/](https://newrelic.com/)
 
 -----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
 ---------------------END OF LICENSE TEXT-----------------------------------------
 

--- a/content/en/docs/corda-os/4.5/legal-info.md
+++ b/content/en/docs/corda-os/4.5/legal-info.md
@@ -140,46 +140,47 @@ This file is based on or incorporates material from the projects listed below (T
 118.	log4j-web
 119.	metrics-core
 120.	metrics-jmx
-121.	mina-core
-122.	minlog
-123.	netty-buffer
-124.	netty-codec
-125.	netty-codec-http
-126.	netty-common
-127.	netty-handler
-128.	netty-resolver
-129.	netty-tcnative-boringssl-static
-130.	netty-transport
-131.	netty-transport-native-epoll
-132.	netty-transport-native-kqueue
-133.	netty-transport-native-unix-common
-134.	newrelic-api
-135.	objenesis
-136.	okhttp
-137.	okio
-138.	picocli
-139.	proton-j
-140.	quasar-core
-141.	reflectasm
-142.	rxjava
-143.	shiro-cache
-144.	shiro-config-core
-145.	shiro-config-ogdl
-146.	shiro-core
-147.	shiro-crypto-cipher
-148.	shiro-crypto-core
-149.	shiro-crypto-hash
-150.	shiro-event
-151.	shiro-lang
-152.	slf4j-api
-153.	slf4j-nop
-154.	snakeyaml
-155.	snappy
-156.	sshd-common
-157.	sshd-core
-158.	sshd-pam
-159.	stay-ex
-160.	txw2
+121.	metrics-new-relic
+122.	mina-core
+123.	minlog
+124.	netty-buffer
+125.	netty-codec
+126.	netty-codec-http
+127.	netty-common
+128.	netty-handler
+129.	netty-resolver
+130.	netty-tcnative-boringssl-static
+131.	netty-transport
+132.	netty-transport-native-epoll
+133.	netty-transport-native-kqueue
+134.	netty-transport-native-unix-common
+135.	newrelic-api
+136.	objenesis
+137.	okhttp
+138.	okio
+139.	picocli
+140.	proton-j
+141.	quasar-core
+142.	reflectasm
+143.	rxjava
+144.	shiro-cache
+145.	shiro-config-core
+146.	shiro-config-ogdl
+147.	shiro-core
+148.	shiro-crypto-cipher
+149.	shiro-crypto-core
+150.	shiro-crypto-hash
+151.	shiro-event
+152.	shiro-lang
+153.	slf4j-api
+154.	slf4j-nop
+155.	snakeyaml
+156.	snappy
+157.	sshd-common
+158.	sshd-core
+159.	sshd-pam
+160.	stay-ex
+161.	txw2
 
 
 ## Start of Notices
@@ -3852,6 +3853,63 @@ from your version.
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
+metrics-new-relic       1.1.1
+[https://github.com/palominolabs/metrics-new-relic](https://github.com/palominolabs/metrics-new-relic)
+[https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE](https://github.com/palominolabs/metrics-new-relic/blob/master/LICENSE)
+
+———————–START OF LICENSE TEXT———————————–
+
+# Copyfree Open Innovation License
+
+This is version 0.4 of the Copyfree Open Innovation License.
+
+## Terms and Conditions
+
+Redistributions, modified or unmodified, in whole or in part, must retain
+applicable copyright or other legal privilege notices, these conditions, and
+the following license terms and disclaimer.  Subject to these conditions, the
+holder(s) of copyright or other legal privileges, author(s) or assembler(s),
+and contributors of this work hereby grant to any person who obtains a copy of
+this work in any form:
+
+1. Permission to reproduce, modify, distribute, publish, sell, sublicense, use,
+and/or otherwise deal in the licensed material without restriction.
+
+2. A perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to reproduce, modify, distribute, publish, sell, use, and/or otherwise
+deal in the licensed material without restriction, for any and all patents:
+
+
+a. Held presently or in the future by each such holder of copyright or
+other legal privilege, author or assembler, or contributor, necessarily
+infringed by the contributions alone or by combination with the work, of
+that privilege holder, author or assembler, or contributor.
+
+b. Necessarily infringed by the work at the time that holder of copyright
+or other privilege, author or assembler, or contributor made any
+contribution to the work.
+
+
+NO WARRANTY OF ANY KIND IS IMPLIED BY, OR SHOULD BE INFERRED FROM, THIS LICENSE
+OR THE ACT OF DISTRIBUTION UNDER THE TERMS OF THIS LICENSE, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS, ASSEMBLERS, OR HOLDERS OF
+COPYRIGHT OR OTHER LEGAL PRIVILEGE BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY, WHETHER IN ACTION OF CONTRACT, TORT, OR OTHERWISE ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OF OR OTHER DEALINGS IN THE WORK.
+
+———————END OF LICENSE TEXT—————————————–
+
+=============END OF NOTICES AND INFORMATION for above components=================
+
+
+================================================
+
+================================================
+
+
+=========== START OF NOTICES AND INFORMATION for the following components=========
+
 quasar-core 0.7.10
 Copyright (c) 2013-2018, Parallel Universe Software Co.
 http://docs.paralleluniverse.co/quasar/
@@ -5194,50 +5252,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 =========== START OF NOTICES AND INFORMATION for the following components=========
 
-newrelic-api	3.10.0
-Copyright (c) 2008-2019 New Relic, Inc.
-https://newrelic.com/
-https://docs.newrelic.com/docs/licenses/license-information/other-licenses/new-relic-agent-license
+newrelic-api  3.10.0
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
+[https://newrelic.com/](https://newrelic.com/)
 
 -----------------------START OF LICENSE TEXT-----------------------------------
 
-Copyright (c) 2008-2019 New Relic, Inc.  All rights reserved.
+Copyright (c) 2010-2014 New Relic, Inc. All rights reserved.
 
-Certain inventions disclosed in this file may be claimed within
-patents owned or patent applications filed by New Relic, Inc. or third
-parties.
+Certain inventions disclosed in this file may be claimed within patents owned or patent applications filed by New Relic, Inc. or third parties. Subject to the terms of this notice, New Relic grants you a nonexclusive, nontransferable license, without the right to sublicense, to (a) install and execute one copy of these files on any number of workstations owned or controlled by you and (b) distribute verbatim copies of these files to third parties. As a condition to the foregoing grant, you must provide this notice along with each copy you distribute and you must not remove, alter, or obscure this notice.
 
-Subject to the terms of this notice, New Relic grants you a
-nonexclusive, nontransferable license, without the right to
-sublicense, to (a) install and execute one copy of these files on any
-number of workstations owned or controlled by you and (b) distribute
-verbatim copies of these files to third parties.  As a condition to the
-foregoing grant, you must provide this notice along with each copy you
-distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other
-exploitation of these files is strictly prohibited, except as may be set
-forth in a separate written license agreement between you and New
-Relic.  The terms of any such license agreement will control over this
-notice.  The license stated above will be automatically terminated and
-revoked if you exceed its scope or violate any of the terms of this
-notice.
+All other use, reproduction, modification, distribution, or other exploitation of these
+files is strictly prohibited, except as may be set forth in a separate written license agreement between you and New Relic. The terms of any such license agreement will control over this notice. The license stated above will be automatically terminated and revoked if you exceed its scope or violate any of the terms of this notice.
 
-This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of New Relic, except as
-required for reasonable and customary use in describing the origin of
-this file and reproducing the content of this notice.  You may not
-mark or brand this file with any trade name, trademarks, service
-marks, or product names other than the original brand (if any)
-provided by New Relic.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of New Relic, except as required for reasonable and customary use in describing the origin of this file and reproducing the content of this notice. You may not mark or brand this file with any trade name, trademarks, service marks, or product names other than the original brand (if any) provided by New Relic.
 
-Unless otherwise expressly agreed by New Relic in a separate written
-license agreement, these files are provided AS IS, WITHOUT WARRANTY OF
-ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a
-condition to your use of these files, you are solely responsible for
-such use. New Relic will have no liability to you for direct,
-indirect, consequential, incidental, special, or punitive damages or
-for lost profits or data.
+Unless otherwise expressly agreed by New Relic in a separate written license agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND, including without any implied warranties of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a condition to your use of these files, you are solely responsible for such use. New Relic will have no liability to you for direct, indirect, consequential, incidental, special, or punitive damages or for lost profits or data.
 
 ---------------------END OF LICENSE TEXT-----------------------------------------
 


### PR DESCRIPTION
- EG-4165 Added missing licence info for metrics-new-relic in CE 4.4, CE 4.5, OS 4.4, and OS 4.5
- EG-4165 Updated licence info for newrelic-api in CE 4.2-4.5 and OS 4.3-4.5
- Propagation downstream from #299 
- Superseding #297 