### PR TITLE
EG-4167: Fixed typos, clarified ambiguous sections, tidied up formatting in up…

### DIFF
--- a/content/en/docs/corda-enterprise/4.3/node-upgrade-notes.md
+++ b/content/en/docs/corda-enterprise/4.3/node-upgrade-notes.md
@@ -33,7 +33,7 @@ Note: The protocol is designed to tolerate node outages. During the upgrade proc
 ## Step 1. Drain the node
 
 Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-[Flows](key-concepts-node.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+[Flows](key-concepts-flows.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow

--- a/content/en/docs/corda-enterprise/4.3/node-upgrade-notes.md
+++ b/content/en/docs/corda-enterprise/4.3/node-upgrade-notes.md
@@ -10,11 +10,11 @@ tags:
 - node
 - upgrade
 - notes
-title: Upgrading your node to Corda 4
+title: Upgrading your node to Corda 4.3
 ---
 
 
-# Upgrading your node to Corda 4
+# Upgrading your node to Corda 4.3
 
 Corda releases strive to be backwards compatible, so upgrading a node is fairly straightforward and should not require changes to
 applications. It consists of the following steps:
@@ -32,8 +32,8 @@ Note: The protocol is designed to tolerate node outages. During the upgrade proc
 
 ## Step 1. Drain the node
 
-Before a node, or an application on a node, can be upgraded, the node must be put in [Draining mode](key-concepts-node.md#draining-mode). This brings the currently running
-[Flows](key-concepts-flows.md) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
+[Flows](key-concepts-node.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
@@ -64,7 +64,7 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
 then skip this step. In this situation, a Corda node will auto-update its database on startup.
@@ -72,10 +72,10 @@ then skip this step. In this situation, a Corda node will auto-update its databa
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*.
 (it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
 In both cases ensure that a node configuration `node.conf` file contains:
 
@@ -94,8 +94,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -122,15 +122,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -151,15 +151,15 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.4 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -180,13 +180,13 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -207,12 +207,12 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.2.8* version *JDBC 4.2* into the `drivers` directory.
 
@@ -225,10 +225,10 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
-A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+A script named `migration/.sql` will be generated in the base directory.
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and inserts the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node-database.md#database-management-tool-ref) manual.
@@ -236,13 +236,10 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 ### 3.3. Apply DDL scripts on a database
 
-The generated DDL script can be applied by the database administrator using their tooling of choice.
-The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+The generated DDL script can be applied by the database administrator using their tooling of choice. The script needs to be run by a database user with *administrative* permissions, with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node. (for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -260,13 +257,10 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.3 to 4.4.
 
 The Database Management Tool can execute the remaining data upgrade.
-As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
-The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
+As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions. The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
 
 You can reuse the tool configuration directory (with modifications) created in Step 3.1, or you can run the tool
 accessing the base directory of a Corda node (for which the data update is being performed).
@@ -277,39 +271,35 @@ If you are reusing the tool configuration directory:
 
 
 
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
 ```
 
-
-
-
-
+>
 The option `-b` points to the base directory (with a `node.conf` file, and *drivers* and *cordapps* subdirectories).
-
-
 
 
 ## Step 4. Replace `corda.jar` with the new version
 
+Replace the `corda.jar` with the latest version of Corda.
+
 Download the latest version of Corda from [our Artifactory site](https://software.r3.com/artifactory/webapp/#/artifacts/browse/simple/General/corda/net/corda/corda-node).
-Make sure it’s available on your path, and that you’ve read the [Release notes](release-notes.md). Pay particular attention to which version of Java this
+Make sure it’s available on your path, and that you’ve read the [Corda release notes](release-notes-enterprise.md). Pay particular attention to which version of Java this
 node requires.
 
 
 {{< important >}}
-Corda 4 requires Java 8u171 or any higher Java 8 patchlevel. Java 9+ is not currently supported.
+Corda 4 requires Java 8u171 or any higher Java 8 patch level. Java 9+ is not currently supported.
 
 
 {{< /important >}}
@@ -331,8 +321,8 @@ Your upgrade is complete.
 
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
-distribution. See [Upgrade a Corda 3.X Enterprise Node](https://docs.corda.net/docs/corda-enterprise/3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+distribution. See [Upgrade a Corda 3.X Enterprise Node](../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 
 {{< /warning >}}

--- a/content/en/docs/corda-enterprise/4.4/node-upgrade-notes.md
+++ b/content/en/docs/corda-enterprise/4.4/node-upgrade-notes.md
@@ -13,11 +13,11 @@ tags:
 - node
 - upgrade
 - notes
-title: Upgrading your node to Corda 4
+title: Upgrading your node to Corda 4.4
 ---
 
 
-# Upgrading your node to Corda 4
+# Upgrading your node to Corda 4.4
 
 Corda releases strive to be backwards compatible, so upgrading a node is fairly straightforward and should not require changes to
 applications. It consists of the following steps:
@@ -36,7 +36,7 @@ Note: The protocol is designed to tolerate node outages. During the upgrade proc
 ## Step 1. Drain the node
 
 Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-key-concepts-flows to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+[Flows](cordapps/api-flows.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
@@ -61,13 +61,13 @@ It’s always a good idea to back up your data before upgrading any server. This
 You can simply make a copy of the node’s data directory to enable this. If you use an external non-H2 database, consult your database
 user guide to learn how to make backups.
 
-For a detailed explanation of Corda backup and recovery guarantees, see [Backup recommendations](node/operating/node-administration.md#backup-recommendations) .
+For a detailed explanation of Corda backup and recovery guarantees, see [Backup recommendations](node/operating/node-administration.md#backup-recommendations).
 
 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
 then skip this step. In this situation, a Corda node will auto-update its database on startup.
@@ -75,10 +75,10 @@ then skip this step. In this situation, a Corda node will auto-update its databa
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*.
 (it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
 In both cases ensure that a node configuration `node.conf` file contains:
 
@@ -97,8 +97,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -125,15 +125,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -154,15 +154,15 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.4 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -183,13 +183,13 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -210,12 +210,12 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.2.8* version *JDBC 4.2* into the `drivers` directory.
 
@@ -228,10 +228,10 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
-A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+A script named `migration/.sql` will be generated in the base directory.
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and inserts the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node/operating/node-database.md#database-management-tool-ref) manual.
@@ -239,13 +239,10 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 ### 3.3. Apply DDL scripts on a database
 
-The generated DDL script can be applied by the database administrator using their tooling of choice.
-The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+The generated DDL script can be applied by the database administrator using their tooling of choice. The script needs to be run by a database user with *administrative* permissions, with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node. (for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -263,13 +260,10 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.3 to 4.4.
 
 The Database Management Tool can execute the remaining data upgrade.
-As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
-The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
+As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions. The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
 
 You can reuse the tool configuration directory (with modifications) created in Step 3.1, or you can run the tool
 accessing the base directory of a Corda node (for which the data update is being performed).
@@ -280,28 +274,22 @@ If you are reusing the tool configuration directory:
 
 
 
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
 ```
 
-
-
-
 >
 The option `-b` points to the base directory (with a `node.conf` file, and *drivers* and *cordapps* subdirectories).
-
-
 
 
 ## Step 4. Replace `corda.jar` with the new version
@@ -314,7 +302,7 @@ node requires.
 
 
 {{< important >}}
-Corda 4 requires Java 8u171 or any higher Java 8 patchlevel. Java 9+ is not currently supported.
+Corda 4 requires Java 8u171 or any higher Java 8 patch level. Java 9+ is not currently supported.
 
 
 {{< /important >}}
@@ -336,7 +324,7 @@ Your upgrade is complete.
 
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 

--- a/content/en/docs/corda-enterprise/4.4/node/operating/cm-upgrading-node.md
+++ b/content/en/docs/corda-enterprise/4.4/node/operating/cm-upgrading-node.md
@@ -11,11 +11,11 @@ tags:
 - cm
 - upgrading
 - node
-title: Upgrading Corda versions on a node
+title: Upgrading your node to Corda 4.4
 weight: 1
 ---
 
-# Upgrading Corda versions on a node
+# Upgrading your node to Corda 4.4
 
 Corda releases strive to be backwards compatible, so upgrading a node is fairly straightforward and should not require changes to
 applications. It consists of the following steps:
@@ -34,7 +34,7 @@ Note: The protocol is designed to tolerate node outages. During the upgrade proc
 ## Step 1. Drain the node
 
 Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-flows to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+[Flows](../../cordapps/api-flows.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
@@ -47,7 +47,7 @@ is complete.
 {{< warning >}}
 The length of time a node takes to drain depends both on how your applications are designed, and whether any apps are currently
 talking to network peers that are offline or slow to respond. It is, therefore, difficult to give guidance on how long a drain should take. In
-an environment with well written apps and in which your counterparties are online, it is possible that drains may only need a few seconds.
+an environment with well-written apps and in which your counterparties are online, it is possible that drains may only need a few seconds.
 
 {{< /warning >}}
 
@@ -65,7 +65,7 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
 then skip this step. In this situation, a Corda node will auto-update its database on startup.
@@ -73,10 +73,9 @@ then skip this step. In this situation, a Corda node will auto-update its databa
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
-(it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+(it can modify database schema).
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database and a Corda node connects with *administrative permissions*.
 
 In both cases ensure that a node configuration `node.conf` file contains:
 
@@ -95,8 +94,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -123,15 +122,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -152,15 +151,15 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.2 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -181,13 +180,13 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -208,12 +207,12 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.1.4* version *JDBC 4.2* into the `drivers` directory.
 
@@ -226,10 +225,10 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
 A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and inserts the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node-database.md#database-management-tool-ref) manual.
@@ -239,11 +238,11 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 The generated DDL script can be applied by the database administrator using their tooling of choice.
 The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node.
+(for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -262,8 +261,8 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 ### 3.4. Apply data updates on a database
 
 The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+and specific node configuration (for example, node legal name).
+Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.5 to 4.6.
 
 The Database Management Tool can execute the remaining data upgrade.
 As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
@@ -276,49 +275,37 @@ however the Database Migration Tool needs to be run from within the same machine
 
 If you are reusing the tool configuration directory:
 
-
-
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node `O=PartyA,L=London,C=GB`, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
 ```
 
-
-
-
 >
 The option `-b` points to the base directory (with a `node.conf` file, and *drivers* and *cordapps* subdirectories).
-
-
 
 
 ## Step 4. Replace `corda.jar` with the new version
 
 Replace the `corda.jar` with the latest version of Corda.
-Make sure it’s available on your path, and that you’ve read the [release notes](../../release-notes.md). Pay particular attention to which version of Java this
-node requires.
+Make sure it’s available on your path, and that you’ve read the [release notes](../../release-notes.md). Pay particular attention to which version of Java this node requires.
 
 
 {{< important >}}
 Corda 4 requires Java 8u171 or any higher Java 8 patchlevel. Java 9+ is not currently supported.
-
-
 {{< /important >}}
 
+## Step 5. Start the node in the normal way
 
-## Step 5. Start up the node
-
-Start the node in the usual manner you have selected. The node will perform any automatic data migrations required, which may take some
+Start the node in the normal way. The node will perform any automatic data migrations required, which may take some
 time. If the migration process is interrupted, it can be continued without harm simply by starting the node again.
 
 
@@ -332,7 +319,7 @@ Your upgrade is complete.
 
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](https://docs.corda.net/docs/corda-enterprise/3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 

--- a/content/en/docs/corda-enterprise/4.5/node-upgrade-notes.md
+++ b/content/en/docs/corda-enterprise/4.5/node-upgrade-notes.md
@@ -9,11 +9,11 @@ tags:
 - node
 - upgrade
 - notes
-title: Upgrading your node to Corda 4
+title: Upgrading your node to Corda 4.5
 ---
 
 
-# Upgrading your node to Corda 4
+# Upgrading your node to Corda 4.5
 
 Corda releases strive to be backwards compatible, so upgrading a node is fairly straightforward and should not require changes to
 applications. It consists of the following steps:
@@ -26,13 +26,18 @@ applications. It consists of the following steps:
 * Start up the node. (This step may incur a delay while any necessary database migrations are applied.)
 * Undrain the node. (This step re-enables processing of new inbound flows.)
 
-Note: The protocol is designed to tolerate node outages. During the upgrade process, peers on the network will wait for your node to come back.
+{{< note >}}
+The protocol is designed to tolerate node outages. During the upgrade process, peers on the network will wait for your node to come back.
+{{< /note >}}
 
+{{< note >}}
+To update from Corda 3.x to 4.6, you must first upgrade to 4.x, and then upgrade to 4.6. We recommend you upgrade to 4.5 and then to 4.6.
+{{< /note >}}
 
 ## Step 1. Drain the node
 
 Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-key-concepts-flows to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+[Flows](cordapps/api-flows.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
@@ -63,28 +68,23 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
-
-If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
-then skip this step. In this situation, a Corda node will auto-update its database on startup.
+This step is mandatory for production systems.
 
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
-(it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+(it can modify database schema).
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
-In both cases ensure that a node configuration `node.conf` file contains:
+In both cases, start the node with the `run-migration-scripts` sub-command with `--core-schemas` and `--app-schemas`.
 
-```groovy
-database = {
-    runMigration = true
-    #other properties
-}
+```bash
+java -jar corda.jar run-migration-scripts --core-schemas --app-schemas
 ```
 
+The node will perform any automatic data migrations required, which may take some time. If the migration process is interrupted it can be continued simply by starting the node again, without harm. The node will stop automatically when migration is complete.
 
 ### 3.1. Configure the Database Management Tool
 
@@ -93,8 +93,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -113,7 +113,6 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
@@ -121,15 +120,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -144,21 +143,20 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.4 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -173,19 +171,18 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -200,18 +197,17 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.2.8* version *JDBC 4.2* into the `drivers` directory.
 
@@ -221,14 +217,16 @@ Copy the PostgreSQL JDBC Driver *42.2.8* version *JDBC 4.2* into the `drivers` d
 To run the tool, use the following command:
 
 ```shell
-java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
+java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory --core-schemas --app-schemas
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
-A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
-and inserts the Liquibase management table *DATABASECHANGELOG*.
+`--core-schemas` is required to adopt the changes made in the new version of Corda, and `--app-schemas` is related to the CorDapps changes.
+
+A script named `migrationYYYYMMDDHHMMSS.sql` will be generated in the current directory.
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
+and updates the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node/operating/node-database.md#database-management-tool-ref) manual.
 
@@ -237,11 +235,11 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 The generated DDL script can be applied by the database administrator using their tooling of choice.
 The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node.
+(for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -259,9 +257,7 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.5 to 4.6.
 
 The Database Management Tool can execute the remaining data upgrade.
 As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
@@ -275,29 +271,27 @@ however the Database Migration Tool needs to be run from within the same machine
 If you are reusing the tool configuration directory:
 
 
-
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node `O=PartyA,L=London,C=GB`, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
-java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
+java -jar tools-database-manager-4.0-RC03.jar execute-migration -b . --core-schemas --app-schemas
 ```
 
 
 
 
->
+
 The option `-b` points to the base directory (with a `node.conf` file, and *drivers* and *cordapps* subdirectories).
 
-
+`--core-schemas` is required to adopt the changes made in the new version of Corda, and `--app-schemas` is related to the CorDapps changes.
 
 
 ## Step 4. Replace `corda.jar` with the new version
@@ -305,21 +299,20 @@ The option `-b` points to the base directory (with a `node.conf` file, and *driv
 Replace the `corda.jar` with the latest version of Corda.
 
 Download the latest version of Corda from [our Artifactory site](https://software.r3.com/artifactory/webapp/#/artifacts/browse/simple/General/corda/net/corda/corda-node).
-Make sure it’s available on your path, and that you’ve read the [Corda release notes](../../corda-os/4.5/release-notes.md). Pay particular attention to which version of Java this
+Make sure it’s available on your path, and that you’ve read the [Corda release notes](../../corda-os/4.6/release-notes.md). Pay particular attention to which version of Java this
 node requires.
 
 
 {{< important >}}
-Corda 4 requires Java 8u171 or any higher Java 8 patchlevel. Java 9+ is not currently supported.
+Corda 4 requires Java 8u171 or any higher Java 8 patch level. Java 9+ is not currently supported.
 
 
 {{< /important >}}
 
 
-## Step 5. Start up the node
+## Step 5. Start the node in the normal way
 
-Start the node in the usual manner you have selected. The node will perform any automatic data migrations required, which may take some
-time. If the migration process is interrupted, it can be continued without harm simply by starting the node again.
+Start the node in the normal way.
 
 
 ## Step 6. Undrain the node
@@ -332,7 +325,7 @@ Your upgrade is complete.
 
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 

--- a/content/en/docs/corda-enterprise/4.5/node/operating/cm-upgrading-node.md
+++ b/content/en/docs/corda-enterprise/4.5/node/operating/cm-upgrading-node.md
@@ -7,43 +7,38 @@ tags:
 - cm
 - upgrading
 - node
-title: Upgrading Corda versions on a node
+title: Upgrading your node to Corda 4.5
 weight: 1
 ---
 
-# Upgrading Corda versions on a node
+# Upgrading your node to Corda 4.5
 
 Corda releases strive to be backwards compatible, so upgrading a node is fairly straightforward and should not require changes to
 applications. It consists of the following steps:
 
-
 * Drain the node.
-* Make a backup of your node directories and database.
-* Update the database.
+* Make a backup of your node directories and/or database.
 * Replace the `corda.jar` file with the new version.
-* Start up the node. (This step may incur a delay while any necessary database migrations are applied.)
-* Undrain the node. (This step re-enables processing of new inbound flows.)
+* Start up the node. This step may incur a delay whilst any needed database migrations are applied.
+* Undrain it to re-enable processing of new inbound flows.
 
-Note: The protocol is designed to tolerate node outages. During the upgrade process, peers on the network will wait for your node to come back.
+The protocol is designed to tolerate node outages, so during the upgrade process peers on the network will wait for your node to come back.
 
 
 ## Step 1. Drain the node
 
-Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-flows to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+Before a node or application on it can be upgraded, the node must be put in Draining mode. This brings the currently running
+[Flows](../../cordapps/api-flows.md/) to a smooth halt such that existing work is finished and new work is queuing up rather than being processed.
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
-able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
-and protocol complexity increases.
+able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become infeasible as workflow and protocol complexity increases.
 
-To drain the node, run the `gracefulShutdown` command. This will wait for the node to drain and then shut it down once the drain
-is complete.
-
+To drain the node, run the `gracefulShutdown` command. This will wait for the node to drain and then shut down the node when the drain is complete.
 
 {{< warning >}}
-The length of time a node takes to drain depends both on how your applications are designed, and whether any apps are currently
-talking to network peers that are offline or slow to respond. It is, therefore, difficult to give guidance on how long a drain should take. In
-an environment with well written apps and in which your counterparties are online, it is possible that drains may only need a few seconds.
+The length of time a node takes to drain depends on both how your applications are designed, and whether any apps are currently
+talking to network peers that are offline or slow to respond. It is thus hard to give guidance on how long a drain should take, but in
+an environment with well written apps and in which your counterparties are online, drains may need only a few seconds.
 
 {{< /warning >}}
 
@@ -61,7 +56,7 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
 then skip this step. In this situation, a Corda node will auto-update its database on startup.
@@ -69,16 +64,15 @@ then skip this step. In this situation, a Corda node will auto-update its databa
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
-(it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+(it can modify database schema).
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
 In both cases ensure that a node configuration `node.conf` file contains:
 
 ```groovy
 database = {
-    runMigration = true
     #other properties
 }
 ```
@@ -91,8 +85,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -111,7 +105,6 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
@@ -119,15 +112,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders <server>, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name -  for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -142,21 +135,20 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.2 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -171,19 +163,18 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -198,18 +189,17 @@ dataSourceProperties = {
     dataSource.password = <password>
 }
 database = {
-    transactionIsolationLevel = READ_COMMITTED
     schema = <schema>
 }
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.1.4* version *JDBC 4.2* into the `drivers` directory.
 
@@ -222,10 +212,10 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
-A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+A script named `migration/.sql` will be generated in the base directory.
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and inserts the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node-database.md#database-management-tool-ref) manual.
@@ -235,11 +225,11 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 The generated DDL script can be applied by the database administrator using their tooling of choice.
 The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node.
+(for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -257,13 +247,10 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.5 to 4.6.
 
 The Database Management Tool can execute the remaining data upgrade.
-As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
-The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
+As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions. The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
 
 You can reuse the tool configuration directory (with modifications) created in Step 3.1, or you can run the tool
 accessing the base directory of a Corda node (for which the data update is being performed).
@@ -272,18 +259,15 @@ however the Database Migration Tool needs to be run from within the same machine
 
 If you are reusing the tool configuration directory:
 
-
-
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node `O=PartyA,L=London,C=GB`, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
@@ -312,13 +296,28 @@ Corda 4 requires Java 8u171 or any higher Java 8 patch level. Java 9+ is not cur
 {{< /important >}}
 
 
-## Step 5. Start up the node
+## Step 5. Update configuration
 
-Start the node in the usual manner you have selected. The node will perform any automatic data migrations required, which may take some
-time. If the migration process is interrupted, it can be continued without harm simply by starting the node again.
+Remove any `transactionIsolationLevel`, `initialiseSchema`, or `initialiseAppSchema` entries from the database section of your configuration
 
+## Step 6. Start the node with `run-migration-scripts` sub-command
 
-## Step 6. Undrain the node
+{{< note >}} This step is only required when upgrading to Corda Enterpise 4.6. {{< /note >}}
+
+Start the node with the `run-migration-scripts` sub-command with `--core-schemas` and `--app-schemas`.
+
+```bash
+java -jar corda.jar run-migration-scripts --core-schemas --app-schemas
+```
+
+The node will perform any automatic data migrations required, which may take some
+time. If the migration process is interrupted it can be continued simply by starting the node again, without harm. The node will stop automatically when migration is complete.
+
+## Step 7. Start the node in the normal way
+
+Start the node in the normal way.
+
+## Step 8. Undrain the node
 
 You may now do any checks that you wish to perform, read the logs, and so on. When you are ready, use this command at the shell:
 
@@ -326,12 +325,9 @@ You may now do any checks that you wish to perform, read the logs, and so on. Wh
 
 Your upgrade is complete.
 
-
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](../../../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 
 {{< /warning >}}
-
-

--- a/content/en/docs/corda-enterprise/4.6/node-upgrade-notes.md
+++ b/content/en/docs/corda-enterprise/4.6/node-upgrade-notes.md
@@ -37,7 +37,7 @@ To update from Corda 3.x to 4.6, you must first upgrade to 4.x, and then upgrade
 ## Step 1. Drain the node
 
 Before a node, or an application on a node, can be upgraded, the node must be put in draining-mode. This brings the currently running
-key-concepts-flows to a smooth halt (existing work is finished, and new work is queued rather than being processed).
+[Flows](cordapps/api-flows.md/) to a smooth halt (existing work is finished, and new work is queued rather than being processed).
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
 able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become unfeasible as workflow
@@ -68,17 +68,17 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
-(it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+(it can modify database schema).
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
-In both cases, start the node with the `run-migration-scripts` sub-command with `--core-schemas` and --app-schemas`.
+In both cases, start the node with the `run-migration-scripts` sub-command with `--core-schemas` and `--app-schemas`.
 
 ```bash
 java -jar corda.jar run-migration-scripts --core-schemas --app-schemas
@@ -93,8 +93,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -120,15 +120,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -148,15 +148,15 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.4 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56615).
-Extract the archive, and copy the single file *mssql-jdbc-6.4.0.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.4.0.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -176,13 +176,13 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -202,12 +202,12 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.2.8* version *JDBC 4.2* into the `drivers` directory.
 
@@ -220,12 +220,12 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory --core-schemas --app-schemas
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
 `--core-schemas` is required to adopt the changes made in the new version of Corda, and `--app-schemas` is related to the CorDapps changes.
 
 A script named `migrationYYYYMMDDHHMMSS.sql` will be generated in the current directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and updates the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node/operating/node-database.md#database-management-tool-ref) manual.
@@ -235,11 +235,11 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 The generated DDL script can be applied by the database administrator using their tooling of choice.
 The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node.
+(for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -257,9 +257,7 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.5 to 4.6.
 
 The Database Management Tool can execute the remaining data upgrade.
 As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
@@ -273,17 +271,15 @@ however the Database Migration Tool needs to be run from within the same machine
 If you are reusing the tool configuration directory:
 
 
-
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node `O=PartyA,L=London,C=GB`, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b . --core-schemas --app-schemas
@@ -308,7 +304,7 @@ node requires.
 
 
 {{< important >}}
-Corda 4 requires Java 8u171 or any higher Java 8 patchlevel. Java 9+ is not currently supported.
+Corda 4 requires Java 8u171 or any higher Java 8 patch level. Java 9+ is not currently supported.
 
 
 {{< /important >}}
@@ -329,7 +325,7 @@ Your upgrade is complete.
 
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 

--- a/content/en/docs/corda-enterprise/4.6/node/operating/cm-upgrading-node.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/cm-upgrading-node.md
@@ -31,11 +31,9 @@ Before a node or application on it can be upgraded, the node must be put in Drai
 [Flows](../../cordapps/api-flows.md/) to a smooth halt such that existing work is finished and new work is queuing up rather than being processed.
 
 Draining flows is a key task for node administrators to perform. It exists to simplify applications by ensuring apps don’t have to be
-able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become infeasible as workflow
-and protocol complexity increases.
+able to migrate workflows from any arbitrary point to other arbitrary points, a task that would rapidly become infeasible as workflow and protocol complexity increases.
 
-To drain the node, run the `gracefulShutdown` command. This will wait for the node to drain and then shut down the node when the drain
-is complete.
+To drain the node, run the `gracefulShutdown` command. This will wait for the node to drain and then shut down the node when the drain is complete.
 
 {{< warning >}}
 The length of time a node takes to drain depends on both how your applications are designed, and whether any apps are currently
@@ -58,7 +56,7 @@ For a detailed explanation of Corda backup and recovery guarantees, see [Backup 
 
 ## Step 3. Update database
 
-This step should be performed for production systems.
+This step is mandatory for production systems.
 
 If you are updating a Corda node that is currently using the default H2 database (which should be used for development purposes),
 then skip this step. In this situation, a Corda node will auto-update its database on startup.
@@ -66,10 +64,10 @@ then skip this step. In this situation, a Corda node will auto-update its databa
 You can also skip the manual database update and allow a Corda node to auto-update its database on startup when:
 
 
-* a database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
-(it can modify database schema)
-* you are upgrading a production system, however your policy allows a Corda node to auto-update its database
-and a Corda node connects with *administrative permissions*
+* A database setup is for testing/development purposes and a Corda node connects with *administrative permissions*
+(it can modify database schema).
+* You are upgrading a production system, however your policy allows a Corda node to auto-update its database
+and a Corda node connects with *administrative permissions*.
 
 In both cases ensure that a node configuration `node.conf` file contains:
 
@@ -87,8 +85,8 @@ The tool is configured in a similar manner to the Corda node.
 A base directory needs to be provided with the following content:
 
 
-* a `node.conf` file with database connection settings
-* a `drivers` directory (where the JDBC driver will be placed)
+* A `node.conf` file with database connection settings.
+* A `drivers` directory (where the JDBC driver will be placed).
 
 Create a `node.conf` with the properties for your database.
 `node.conf` templates for each database vendor are shown below.
@@ -114,15 +112,15 @@ myLegalName = <node_legal_name>
 
 
 
-Replace placeholders *<server>*, *<login>*, *<password>*, and *<database>* with appropriate values.
-*<database>* should be a user database and *<schema>* a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders <server>, `<login>`, `<password>`, and `<database>` with appropriate values.
+`<database>` should be a user database and `<schema>` a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory, however, it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name -  for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft SQL JDBC driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### SQL Server
@@ -142,15 +140,15 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<server>*, *<login>*, *<password>*, *<database>* with appropriate values.
-*<database>* is a database name and *<schema>* is a schema namespace.
-Ensure *<login>* and *<password>* are for a database user with visibility of the *<schema>*.
+Replace placeholders `<server>`, `<login>`, `<password>`, `<database>` with appropriate values.
+`<database>` is a database name and `<schema>` is a schema namespace.
+Ensure `<login>` and `<password>` are for a database user with visibility of the `<schema>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 The Microsoft JDBC 6.2 driver can be downloaded from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=55539).
-Extract the archive, and copy the single file *mssql-jdbc-6.2.2.jre8.jar* into the `drivers` directory.
+Extract the archive, and copy the single file `mssql-jdbc-6.2.2.jre8.jar` into the `drivers` directory.
 
 
 #### Oracle
@@ -170,13 +168,13 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>* and *<sid>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is a database schema namespace, for a basic setup the schema name equals *<user>*.
+Replace placeholders `<host>`, `<port>` and `<sid>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is a database schema namespace, for a basic setup the schema name equals `<user>`.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
-Copy the Oracle JDBC driver *ojdbc6.jar* for 11g RC2 or *ojdbc8.jar* for Oracle 12c into the `drivers` directory.
+Copy the Oracle JDBC driver `ojdbc6.jar` for 11g RC2 or `ojdbc8.jar` for Oracle 12c into the `drivers` directory.
 
 
 #### PostgreSQL
@@ -196,12 +194,12 @@ database = {
 myLegalName = <node_legal_name>
 ```
 
-Replace placeholders *<host>*, *<port>*, *<database>*, *<user>*, *<password>* and *<schema>* with appropriate values.
-*<schema>* is the database schema name assigned to the user,
+Replace placeholders `<host>`, `<port>`, `<database>`, `<user>`, `<password>` and `<schema>` with appropriate values.
+`<schema>` is the database schema name assigned to the user,
 the value of `database.schema` is automatically wrapped in double quotes to preserve case-sensitivity.
 The `myLegalName` field is obligatory however it is used in Step 3.4 only
 (the tool doesn’t understand the context of the run and always requires the field to be present).
-For this step you can use any valid dummy name e.g. *O=Dummy,L=London,C=GB* for *<node_legal_name>*.
+For this step you can use any valid dummy name - for example, `O=Dummy,L=London,C=GB` for `<node_legal_name>`.
 
 Copy the PostgreSQL JDBC Driver *42.1.4* version *JDBC 4.2* into the `drivers` directory.
 
@@ -214,10 +212,10 @@ To run the tool, use the following command:
 java -jar tools-database-manager-|release|.jar dry-run -b path_to_configuration_directory
 ```
 
-The option `-b` points to the base directory (which contains a `node.conf` file, and *drivers* and *cordapps* subdirectories).
+The option `-b` points to the base directory (which contains a `node.conf` file, and `drivers` and `cordapps` subdirectories).
 
-A script named *migration/*.sql* will be generated in the base directory.
-This script will contain all the statements required to modify and create data structures (e.g. tables/indexes),
+A script named `migration/.sql` will be generated in the base directory.
+This script will contain all the statements required to modify and create data structures (for example, tables/indexes),
 and inserts the Liquibase management table *DATABASECHANGELOG*.
 The command doesn’t alter any tables itself.
 For descriptions of the options, refer to the [Corda Database Management Tool](node-database.md#database-management-tool-ref) manual.
@@ -227,11 +225,11 @@ For descriptions of the options, refer to the [Corda Database Management Tool](n
 
 The generated DDL script can be applied by the database administrator using their tooling of choice.
 The script needs to be run by a database user with *administrative* permissions,
-with a *<schema>* set as the default schema for that user and matching the schema used by a Corda node.
-(e.g. for Azure SQL or SQL Server you should not use the default database administrator account).
+with a `<schema>` set as the default schema for that user and matching the schema used by a Corda node.
+(for example, for Azure SQL or SQL Server you should not use the default database administrator account).
 
 {{< note >}}
-You may connect as a different user to the one used by a Corda node (e.g. when a node connects via
+You may connect as a different user to the one used by a Corda node (for example, when a node connects via
 a user with *restricted permissions*), as long as your user has the same default schema as the node has.
 (The generated DDL script adds the schema prefix to most of the statements, but not to all of them.)
 
@@ -249,13 +247,10 @@ An accidental re-run of the scripts will fail (as the tables are already there),
 
 ### 3.4. Apply data updates on a database
 
-The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows
-and specific node configuration (e.g. node legal name).
-Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node).
+The schema structure changes in Corda 4.0 require data to be propagated to new tables and columns based on the existing rows and specific node configuration (for example, node legal name). Such migrations cannot be expressed by the DDL script, so they need to be performed by the Database Management Tool (or a Corda node). These updates are required any time you are upgrading either from an earlier version to 4.0 or from 4.x to 4.x - for example, upgrading from 4.5 to 4.6.
 
 The Database Management Tool can execute the remaining data upgrade.
-As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions.
-The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
+As the schema structure is already created in the 3rd step, the tool can connect with *restricted* database permissions. The only activities in this step are inserts/upgrades data rows, and no alterations to the schema are applied.
 
 You can reuse the tool configuration directory (with modifications) created in Step 3.1, or you can run the tool
 accessing the base directory of a Corda node (for which the data update is being performed).
@@ -264,18 +259,15 @@ however the Database Migration Tool needs to be run from within the same machine
 
 If you are reusing the tool configuration directory:
 
-
-
-* ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
-(e.g. while upgrading database schema used by a node *O=PartyA,L=London,C=GB*, assign the same value to `myLegalName`).
+1. Ensure `myLegalName` setting in `node.conf` is set with a node name for which the data update will be run
+(for example, while upgrading database schema used by a node `O=PartyA,L=London,C=GB`, assign the same value to `myLegalName`).
 {{< warning >}}
 Any `node.conf` misconfiguration may cause data row migration to be wrongly applied. This may happen silently (without any error).
 The value of `myLegalName` must exactly match the node name that is used in the given database schema.{{< /warning >}}
 
+2. Create `cordapps` subdirectory and copy the CorDapps used by the Corda node.
 
-
-* create `cordapps` subdirectory and copy the CorDapps used by the Corda node
-* change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
+3. Change the database user to one with *restricted permissions*. This ensures no database alteration is performed by this step.To run the remaining data migration, run:
 
 ```shell
 java -jar tools-database-manager-4.0-RC03.jar execute-migration -b .
@@ -334,7 +326,7 @@ You may now do any checks that you wish to perform, read the logs, and so on. Wh
 Your upgrade is complete.
 
 {{< warning >}}
-if upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
+If upgrading from Corda Enterprise 3.x, please ensure your node has been upgraded to the latest point release of that
 distribution. See [Upgrade a Corda 3.X Enterprise Node](../../../3.3/node-operations-upgrading.html#upgrading-a-corda-enterprise-node)
 for information on upgrading Corda 3.x versions.
 


### PR DESCRIPTION
…grading nodes docs.

Note: Only 'node-upgrade-notes.md' was corrected in 4.3 because the other file ('cm-upgrading-node.md') does not exist in that version.
