### PR TITLE
EG-4038 Fixed broken link and added new links on the home page for the CENM 1.4

### DIFF
--- a/themes/hugo-r3-theme/layouts/index.html
+++ b/themes/hugo-r3-theme/layouts/index.html
@@ -416,8 +416,14 @@
         <li><a href="docs/cenm/1.4/release-notes.html">Release
         notes</a></li>
 
-        <li><a href="docs/cenm/1.4/legal-info.html">Third-party
-        software license information</a></li>
+        <li><a href="docs/cenm/1.4/release-checksum-cenm.html">Release files
+        and checksums</a></li>
+
+        <li><a href="docs/cenm/1.4/legal-info-1.4.0.html">Third-party
+        software license information - CENM 1.4.0</a></li>
+
+        <li><a href="docs/cenm/1.4/legal-info-1.4.1.html">Third-party
+        software license information - CENM 1.4.1</a></li>
       </ul>
     </li>
 


### PR DESCRIPTION
EG-4038 Fixed broken link on the home page for the CENM 1.4.0 legal info page, added one for CENM 1.4.1, and added a link to the artifacts and checksums page