### PR TITLE
Fix the Docker image name of cenm-cli

### DIFF
--- a/content/en/docs/corda-enterprise/4.6/operations/deployment/deployment-kubernetes.md
+++ b/content/en/docs/corda-enterprise/4.6/operations/deployment/deployment-kubernetes.md
@@ -106,7 +106,7 @@ The deployment steps are given below:
 - Download the Docker image with CENM [Command-Line Interface (CLI) tool](../../../../cenm/1.4/cenm-cli-tool.md) so you can manage CENM services:
 
     ```bash
-    docker pull cenm-cli:1.3-zulu-openjdk8u242
+    docker pull corda/enterprise-cenm-cli:1.4-zulu-openjdk8u242
     ```
 
 #### 2. Set up the Kubernetes cluster


### PR DESCRIPTION
The correct name of the Docker image of `cenm-cli` is `corda/enterprise-cenm-cli`. If the user runs `docker pull cenm-cli`, he will get the following error and so create confusion:
```
Error response from daemon: pull access denied for cenm-cli, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```