### PR TITLE
EG-4578 Add k8s storage class configuration

### DIFF
--- a/content/en/docs/cenm/1.4/deployment-kubernetes.md
+++ b/content/en/docs/cenm/1.4/deployment-kubernetes.md
@@ -130,6 +130,7 @@ Run the following instruction once the previous points have been cleared:
 `All the examples below use the namespace **cenm**`
 
 ```bash
+kubectl apply -f deployment/k8s/storage-class-[aws|azure].yaml
 kubectl apply -f deployment/k8s/cenm.yaml
 export nameSpace=cenm
 kubectl config set-context $(kubectl config current-context) --namespace=${nameSpace}


### PR DESCRIPTION
In order to successfully start the pods in the k8s cluster, the user has to set the storage class type accordingly with the cloud provider in use (Azure or AWS).
Without it, the pods will be stuck in a _pending_ status forever and the user will see this error:

`0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims.`

Related to EG-4578.