### PR TITLE
EG-4500 [ENT-6012] Update 'Querying flow data' doc page clarifying that the multi-RPC client should be aligned with the node version

### DIFF
--- a/content/en/docs/corda-enterprise/4.6/node/operating/querying-flow-data.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/querying-flow-data.md
@@ -46,6 +46,10 @@ val flowStatusRPCOPs = conn.proxy
 ```
 To view the full code sample, see [NodeFlowStatusRpcOps.kt](../../resources/extensions-rpc/NodeFlowStatusRpcOps.kt).
 
+{{< warning >}}
+The Multi RPC Client version must be aligned with the node version, meaning that both must be running the same Corda Enterprise version.
+{{< /warning >}}
+
 For details of how to build a Multi RPC Client, see [Building a Multi RPC Client](clientrpc.md). See also [MultiRPCClient](https://api.corda.net/api/corda-enterprise/4.6/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
 
 ### Specifying the query criteria


### PR DESCRIPTION
EG-4500 [ENT-6012] Update 'Querying flow data' doc page clarifying that the multi-RPC client should be aligned with the node version