### PR TITLE
adding an import

### DIFF
--- a/content/en/docs/corda-os/4.7/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.7/tutorial-contract.md
@@ -501,7 +501,7 @@ for ((inputs, outputs, _) in groups) {
 
 {{% tab name="java" %}}
 ```java
-import net.corda.finance.contracts.utils.sumCashBy
+import net.corda.finance.contracts.utils.sumCashBy;
 
 TimeWindow timeWindow = tx.getTimeWindow();
 

--- a/content/en/docs/corda-os/4.7/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.7/tutorial-contract.md
@@ -501,6 +501,8 @@ for ((inputs, outputs, _) in groups) {
 
 {{% tab name="java" %}}
 ```java
+import net.corda.finance.contracts.utils.sumCashBy
+
 TimeWindow timeWindow = tx.getTimeWindow();
 
 for (InOutGroup group : groups) {

--- a/content/en/docs/corda-os/4.7/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.7/tutorial-contract.md
@@ -881,6 +881,12 @@ being consumed must have its encumbrance consumed in the same transaction, other
 
 The encumbrance reference is optional in the `ContractState` interface:
 
+If you're using Java, you may want to add this jar to your gradle dependencies for this code example to compile.  
+
+```
+cordaCompile "$corda_release_group:corda-finance-contracts:$corda_release_version"
+```
+
 {{< tabs name="tabs-12" >}}
 {{% tab name="kotlin" %}}
 ```kotlin


### PR DESCRIPTION
For those following the tutorial we want to include that import to make it clearer to them where the sumCashBy is coming from in this java example of the contracts tutorial here: https://docs.corda.net/docs/corda-os/4.7/tutorial-contract.html#checking-the-requirements

This is based on my interaction with Andrea d'Auria here : https://cordaledger.slack.com/archives/C2KGD72UX/p1609865285066000 

He also kindly outlined he needed to add another jar in order for him to continue to follow the tutorial. 

not sure if you'd like to add this as well. 
```
cordaCompile "$corda_release_group:corda-finance-contracts:$corda_release_version"
```

thanks 