### PR TITLE
EG-3921: Added missing code snippets to OS 4.7 tutorials

### DIFF
--- a/content/en/docs/corda-os/4.7/event-scheduling.md
+++ b/content/en/docs/corda-os/4.7/event-scheduling.md
@@ -98,11 +98,15 @@ Let’s take the example of heartbeat sample in our `samples` repositories ([Kot
 {{% tab name="java" %}}
 ```java
 // Defines the scheduled activity to be conducted by the SchedulableState.
-   override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
-       // A heartbeat will be emitted every second. We get the time when the scheduled activity will occur in the constructor rather than in this method. This is
-       // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather than the time at which the state was created.
-       return ScheduledActivity(flowLogicRefFactory.create("com.heartbeat.flows.HeartbeatFlow", thisStateRef), nextActivityTime)
-   }
+    @Nullable
+    @Override
+    public ScheduledActivity nextScheduledActivity(@NotNull StateRef thisStateRef, @NotNull FlowLogicRefFactory flowLogicRefFactory) {
+        // A heartbeat will be emitted every second.
+        // We get the time when the scheduled activity will occur in the constructor rather than in this method. This is
+        // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather
+        // than the time at which the state was created.
+        return new ScheduledActivity(flowLogicRefFactory.create("net.corda.samples.heartbeat.flows.HeartbeatFlow", thisStateRef), nextActivityTime);
+    }
 
 ```
 {{% /tab %}}

--- a/content/en/docs/corda-os/4.7/event-scheduling.md
+++ b/content/en/docs/corda-os/4.7/event-scheduling.md
@@ -79,29 +79,31 @@ encounter but which aren’t related to yourself will not have any activities sc
 
 ## Example
 
-Let’s take the example of fixing an interest rate swap. The first task is to implement the
+Let’s take the example of heartbeat sample in our `samples` repositories ([Kotlin](https://github.com/corda/samples-kotlin/tree/master/Features/schedulableState-heartbeat), [Java](https://github.com/corda/samples-java/tree/master/Features/schedulablestate-heartbeat)). The first task is to implement the
 `nextScheduledActivity` method on the `State`.
 
 {{< tabs name="tabs-1" >}}
 {{% tab name="kotlin" %}}
 ```kotlin
-override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
-    val nextFixingOf = nextFixingOf() ?: return null
+// Defines the scheduled activity to be conducted by the SchedulableState.
+    override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+        // A heartbeat will be emitted every second. We get the time when the scheduled activity will occur in the constructor rather than in this method. This is
+        // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather than the time at which the state was created.
+        return ScheduledActivity(flowLogicRefFactory.create("com.heartbeat.flows.HeartbeatFlow", thisStateRef), nextActivityTime)
+    }
 
-    // This is perhaps not how we should determine the time point in the business day, but instead expect the schedule to detail some of these aspects
-    val instant = suggestInterestRateAnnouncementTimeWindow(index = nextFixingOf.name, source = floatingLeg.indexSource, date = nextFixingOf.forDay).fromTime!!
-    return ScheduledActivity(flowLogicRefFactory.create("net.corda.irs.flows.FixingFlow\$FixingRoleDecider", thisStateRef), instant)
-}
+```
+{{% /tab %}}
+
+{{% tab name="java" %}}
+```java
+// Defines the scheduled activity to be conducted by the SchedulableState.
+   override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+       // A heartbeat will be emitted every second. We get the time when the scheduled activity will occur in the constructor rather than in this method. This is
+       // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather than the time at which the state was created.
+       return ScheduledActivity(flowLogicRefFactory.create("com.heartbeat.flows.HeartbeatFlow", thisStateRef), nextActivityTime)
+   }
 
 ```
 {{% /tab %}}
 {{< /tabs >}}
-
-[IRS.kt](https://github.com/corda/corda/blob/release/os/4.7/samples/irs-demo/cordapp/contracts-irs/src/main/kotlin/net/corda/irs/contract/IRS.kt)
-
-The first thing this does is establish if there are any remaining fixings. If there are none, then it returns `null`
-to indicate that there is no activity to schedule. Otherwise, it calculates the `Instant` at which the interest rate
-should become available and schedules an activity at that time to work out what roles each node will take in the fixing
-business process and to take on those roles. That `FlowLogic` will be handed the `StateRef` for the interest
-rate swap `State` in question, as well as a tolerance `Duration` of how long to wait after the activity is triggered
-for the interest rate before indicating an error.

--- a/content/en/docs/corda-os/4.7/flow-testing.md
+++ b/content/en/docs/corda-os/4.7/flow-testing.md
@@ -31,7 +31,7 @@ means that unit testing a flow requires some infrastructure to provide lightweig
 
 The `MockNetwork` class provides this testing infrastructure layer; you can find this class in the `test-utils` module.
 
-A good example to examine for learning how to unit test flows is the `IOUTransferFlowTests` tests. This test file sits in our sample repositories under `Advanced/obligation-cordapp` and is available in both [Kotlin](https://github.com/corda/samples-kotlin/tree/master/Advanced/obligation-cordapp) and [Java](https://github.com/corda/samples-java/tree/master/Advanced/obligation-cordapp) versions.
+The `IOUTransferFlowTests` tests provide a good example for learning how to unit test flows. This test file sits in our sample repositories under `Advanced/obligation-cordapp` and is available in both [Kotlin](https://github.com/corda/samples-kotlin/tree/master/Advanced/obligation-cordapp) and [Java](https://github.com/corda/samples-java/tree/master/Advanced/obligation-cordapp) versions.
 
 Setup codes for both versions are shown here:
 
@@ -183,4 +183,4 @@ fun flowReturnsCorrectlyFormedPartiallySignedTransaction() {
 
 {{< /tabs >}}
 
-The logic of writing a tester is very intuitive. You are essentially mimicking what the flow does, composing the transaction, and collecting required signatures. In our example above, we first created the state attributes and package them into a state. Then we start the flow by a mock node. For the verification process, we take the obtained signed transaction and assert the required fields of the transaction as well as that of the input/output states. 
+Writing a test is an intuitive process. You are essentially mimicking what the flow does, composing the transaction, and collecting required signatures. In our example above, we first create the state attributes and package them into a state. Then we start the flow with a mock node. For the verification process, we take the obtained signed transaction and assert the required fields of the transaction as well as that of the input/output states.

--- a/content/en/docs/corda-os/4.7/flow-testing.md
+++ b/content/en/docs/corda-os/4.7/flow-testing.md
@@ -31,51 +31,84 @@ means that unit testing a flow requires some infrastructure to provide lightweig
 
 The `MockNetwork` class provides this testing infrastructure layer; you can find this class in the `test-utils` module.
 
-A good example to examine for learning how to unit test flows is the `ResolveTransactionsFlow` tests. This
-flow takes care of downloading and verifying transaction graphs, with all the needed dependencies. We start
-with this basic skeleton:
+A good example to examine for learning how to unit test flows is the `IOUTransferFlowTests` tests. This test file sits in our sample repositories under `Advanced/obligation-cordapp` and is available in both [Kotlin](https://github.com/corda/samples-kotlin/tree/master/Advanced/obligation-cordapp) and [Java](https://github.com/corda/samples-java/tree/master/Advanced/obligation-cordapp) versions.
 
+Setup codes for both versions are shown here:
+
+{{< tabs name="tabs-1" >}}
+{{% tab name="kotlin" %}}
 ```kotlin
-class ResolveTransactionsFlowTest {
-    private lateinit var mockNet: MockNetwork
-    private lateinit var notaryNode: StartedMockNode
-    private lateinit var megaCorpNode: StartedMockNode
-    private lateinit var miniCorpNode: StartedMockNode
-    private lateinit var newNotaryNode: StartedMockNode
-    private lateinit var megaCorp: Party
-    private lateinit var miniCorp: Party
-    private lateinit var notary: Party
-    private lateinit var newNotary: Party
+
+class IOUTransferFlowTests {
+    lateinit var mockNetwork: MockNetwork
+    lateinit var a: StartedMockNode
+    lateinit var b: StartedMockNode
+    lateinit var c: StartedMockNode
 
     @Before
     fun setup() {
-        val mockNetworkParameters = MockNetworkParameters(
-                cordappsForAllNodes = listOf(DUMMY_CONTRACTS_CORDAPP, enclosedCordapp()),
-                notarySpecs = listOf(
-                        MockNetworkNotarySpec(DUMMY_NOTARY_NAME),
-                        MockNetworkNotarySpec(DUMMY_BANK_A_NAME)
-                )
-        )
-        mockNet = MockNetwork(mockNetworkParameters)
-        notaryNode = mockNet.notaryNodes.first()
-        megaCorpNode = mockNet.createPartyNode(CordaX500Name("MegaCorp", "London", "GB"))
-        miniCorpNode = mockNet.createPartyNode(CordaX500Name("MiniCorp", "London", "GB"))
-        notary = notaryNode.info.singleIdentity()
-        megaCorp = megaCorpNode.info.singleIdentity()
-        miniCorp = miniCorpNode.info.singleIdentity()
-        newNotaryNode = mockNet.notaryNodes[1]
-        newNotary = mockNet.notaryNodes[1].info.singleIdentity()
+        mockNetwork = MockNetwork(listOf("net.corda.training"),
+                notarySpecs = listOf(MockNetworkNotarySpec(CordaX500Name("Notary","London","GB"))))
+        a = mockNetwork.createNode(MockNodeParameters())
+        b = mockNetwork.createNode(MockNodeParameters())
+        c = mockNetwork.createNode(MockNodeParameters())
+        val startedNodes = arrayListOf(a, b, c)
+        // For real nodes this happens automatically, but we have to manually register the flow for tests
+        startedNodes.forEach { it.registerInitiatedFlow(IOUIssueFlowResponder::class.java) }
+        startedNodes.forEach { it.registerInitiatedFlow(IOUTransferFlowResponder::class.java) }
+        mockNetwork.runNetwork()
     }
 
     @After
     fun tearDown() {
-        mockNet.stopNodes()
-        System.setProperty("net.corda.node.dbtransactionsresolver.InMemoryResolutionLimit", "0")
+        mockNetwork.stopNodes()
     }
 
 ```
+{{% /tab %}}
 
-[ResolveTransactionsFlowTest.kt](https://github.com/corda/corda/blob/release/os/4.7/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt)
+{{% tab name="java" %}}
+```java
+
+public class IOUTransferFlowTests {
+
+    private MockNetwork mockNetwork;
+    private StartedMockNode a, b, c;
+
+    @Before
+    public void setup() {
+        MockNetworkParameters mockNetworkParameters = new MockNetworkParameters().withCordappsForAllNodes(
+                Arrays.asList(
+                        TestCordapp.findCordapp("net.corda.samples.contracts")
+                )
+        ).withNotarySpecs(Arrays.asList(new MockNetworkNotarySpec(new CordaX500Name("Notary", "London", "GB"))));
+        mockNetwork = new MockNetwork(mockNetworkParameters);
+        System.out.println(mockNetwork);
+
+        a = mockNetwork.createNode(new MockNodeParameters());
+        b = mockNetwork.createNode(new MockNodeParameters());
+        c = mockNetwork.createNode(new MockNodeParameters());
+
+        ArrayList<StartedMockNode> startedNodes = new ArrayList<>();
+        startedNodes.add(a);
+        startedNodes.add(b);
+        startedNodes.add(c);
+
+        // For real nodes this happens automatically, but we have to manually register the flow for tests
+        startedNodes.forEach(el -> el.registerInitiatedFlow(IOUTransferFlow.Responder.class));
+        startedNodes.forEach(el -> el.registerInitiatedFlow(IOUIssueFlow.ResponderFlow.class));
+        mockNetwork.runNetwork();
+    }
+
+    @After
+    public void tearDown() {
+        mockNetwork.stopNodes();
+    }
+
+```
+{{% /tab %}}
+
+{{< /tabs >}}
 
 We create a mock network in our `@Before` setup method and create a couple of nodes. We also record the identity
 of the notary in our test network, which will come in handy later. We also tidy up when we’re done.
@@ -84,77 +117,70 @@ of the notary in our test network, which will come in handy later. We also tidy 
 
 Next, we write a test case:
 
+{{< tabs name="tabs-2" >}}
+{{% tab name="kotlin" %}}
 ```kotlin
-@Test(timeout=300_000)
- `resolve from two hashes`() {
-    val (stx1, stx2) = makeTransactions()
-    val p = TestFlow(setOf(stx2.id), megaCorp)
-    val future = miniCorpNode.startFlow(p)
-    mockNet.runNetwork()
-    future.getOrThrow()
-    miniCorpNode.transaction {
-        assertEquals(stx1, miniCorpNode.services.validatedTransactions.getTransaction(stx1.id))
-        assertEquals(stx2, miniCorpNode.services.validatedTransactions.getTransaction(stx2.id))
-    }
+
+@Test
+fun flowReturnsCorrectlyFormedPartiallySignedTransaction() {
+    val lender = a.info.chooseIdentityAndCert().party
+    val borrower = b.info.chooseIdentityAndCert().party
+    val stx = issueIou(IOUState(10.POUNDS, lender, borrower))
+    val inputIou = stx.tx.outputs.single().data as IOUState
+    val flow = IOUTransferFlow(inputIou.linearId, c.info.chooseIdentityAndCert().party)
+    val future = a.startFlow(flow)
+    mockNetwork.runNetwork()
+    val ptx = future.getOrThrow()
+    // Check the transaction is well formed...
+    // One output IOUState, one input state reference and a Transfer command with the right properties.
+    assert(ptx.tx.inputs.size == 1)
+    assert(ptx.tx.outputs.size == 1)
+    assert(ptx.tx.inputs.single() == StateRef(stx.id, 0))
+    println("Input state ref: ${ptx.tx.inputs.single()} == ${StateRef(stx.id, 0)}")
+    val outputIou = ptx.tx.outputs.single().data as IOUState
+    println("Output state: $outputIou")
+    val command = ptx.tx.commands.single()
+    assert(command.value == IOUContract.Commands.Transfer())
+    ptx.verifySignaturesExcept(b.info.chooseIdentityAndCert().party.owningKey, c.info.chooseIdentityAndCert().party.owningKey,
+            mockNetwork.defaultNotaryNode.info.legalIdentitiesAndCerts.first().owningKey)
 }
 
 ```
+{{% /tab %}}
 
-[ResolveTransactionsFlowTest.kt](https://github.com/corda/corda/blob/release/os/4.7/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt)
+{{% tab name="java" %}}
+```java
 
-We’ll take a look at the `makeTransactions` function in a moment. For now, it’s enough to know that it returns two
-`SignedTransaction` objects, the second of which spends the first. Both transactions are known by MegaCorpNode but
-not MiniCorpNode.
+@Test
+    public void flowReturnsCorrectlyFormedPartiallySignedTransaction() throws Exception {
+        Party lender = a.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        Party borrower = b.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        SignedTransaction stx = issueIOU(new IOUState(Currencies.DOLLARS(10), lender, borrower));
+        IOUState inputIou = (IOUState) stx.getTx().getOutputs().get(0).getData();
+        IOUTransferFlow.InitiatorFlow flow = new IOUTransferFlow.InitiatorFlow(inputIou.getLinearId(), c.getInfo().getLegalIdentities().get(0));
+        Future<SignedTransaction> future = a.startFlow(flow);
 
-The test logic is simple enough: we create the flow, giving it MegaCorpNode’s identity as the target to talk to.
-Then we start it on MiniCorpNode and use the `mockNet.runNetwork()` method to bounce messages around until things have
-settled (that is, there are no more messages waiting to be delivered). All this is done using an in memory message
-routing implementation that is fast to initialise and use. Finally, we obtain the result of the flow and do
-some tests on it. We also check the contents of MiniCorpNode’s database to see that the flow had the intended effect
-on the node’s persistent state.
+        mockNetwork.runNetwork();
 
-Here’s what `makeTransactions` looks like:
+        SignedTransaction ptx = future.get();
 
-```kotlin
-private fun makeTransactions(signFirstTX: Boolean = true, withAttachment: SecureHash? = null): Pair<SignedTransaction, SignedTransaction> {
-    // Make a chain of custody of dummy states and insert into node A.
-    val dummy1: SignedTransaction = DummyContract.generateInitial(0, notary, megaCorp.ref(1)).let {
-        if (withAttachment != null)
-            it.addAttachment(withAttachment)
-        when (signFirstTX) {
-            true -> {
-                val ptx = megaCorpNode.services.signInitialTransaction(it)
-                notaryNode.services.addSignature(ptx, notary.owningKey)
-            }
-            false -> {
-                notaryNode.services.signInitialTransaction(it, notary.owningKey)
-            }
-        }
+        // Check the transaction is well formed...
+        // One output IOUState, one input state reference and a Transfer command with the right properties.
+        assert (ptx.getTx().getInputs().size() == 1);
+        assert (ptx.getTx().getOutputs().size() == 1);
+        assert (ptx.getTx().getOutputs().get(0).getData() instanceof IOUState);
+        assert (ptx.getTx().getInputs().get(0).equals(new StateRef(stx.getId(), 0)));
+
+        IOUState outputIOU = (IOUState) ptx.getTx().getOutput(0);
+        Command command = ptx.getTx().getCommands().get(0);
+
+        assert (command.getValue().equals(new IOUContract.Commands.Transfer()));
+        ptx.verifySignaturesExcept(b.getInfo().getLegalIdentities().get(0).getOwningKey(), c.getInfo().getLegalIdentities().get(0).getOwningKey(), mockNetwork.getDefaultNotaryIdentity().getOwningKey());
     }
-    megaCorpNode.transaction {
-        megaCorpNode.services.recordTransactions(dummy1)
-    }
-    val dummy2: SignedTransaction = DummyContract.move(dummy1.tx.outRef(0), miniCorp).let {
-        val ptx = megaCorpNode.services.signInitialTransaction(it)
-        notaryNode.services.addSignature(ptx, notary.owningKey)
-    }
-    megaCorpNode.transaction {
-        megaCorpNode.services.recordTransactions(dummy2)
-    }
-    return Pair(dummy1, dummy2)
-}
 
 ```
+{{% /tab %}}
 
-[ResolveTransactionsFlowTest.kt](https://github.com/corda/corda/blob/release/os/4.7/core-tests/src/test/kotlin/net/corda/coretests/internal/ResolveTransactionsFlowTest.kt)
+{{< /tabs >}}
 
-We’re using the `DummyContract`, a simple test smart contract which stores a single number in its states, along
-with ownership and issuer information. You can issue such states, exit them, and re-assign ownership (move them).
-It doesn’t do anything else. This code simply creates a transaction that issues a dummy state (the issuer is
-`MEGA_CORP`, a pre-defined unit test identity), signs it with the test notary and MegaCorp keys, and then
-converts the builder to the final `SignedTransaction`. It then repeats these steps, but this time, instead of issuing
-it, re-assigns ownership instead. The chain of two transactions is finally committed to MegaCorpNode by sending them
-directly to the `megaCorpNode.services.recordTransaction` method (note that this method doesn’t check that the
-transactions are valid) inside a `database.transaction`. All node flows run within a database transaction in the
-nodes themselves, but any time you need to use the database directly from a unit test, you need to provide a database
-transaction as shown here.
+The logic of writing a tester is very intuitive. You are essentially mimicking what the flow does, composing the transaction, and collecting required signatures. In our example above, we first created the state attributes and package them into a state. Then we start the flow by a mock node. For the verification process, we take the obtained signed transaction and assert the required fields of the transaction as well as that of the input/output states. 

--- a/content/en/docs/corda-os/4.7/tut-two-party-contract.md
+++ b/content/en/docs/corda-os/4.7/tut-two-party-contract.md
@@ -63,6 +63,10 @@ and:
 * Throws an `IllegalArgumentException` if it rejects the transaction proposal
 * Returns silently if it accepts the transaction proposal
 
+{{< note >}}
+As mentioned in the [Writing the state](hello-world-state.md) tutorial, this is Corda source code and is therefore written in Kotlin.
+{{< /note >}}
+
 ## Controlling IOU evolution
 
 What would a good contract for an `IOUState` look like? There is no right or wrong answer - it depends on how you

--- a/content/en/docs/corda-os/4.7/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.7/tutorial-contract.md
@@ -675,6 +675,20 @@ fun generateIssue(issuance: PartyAndReference, faceValue: Amount<Issued<Currency
 
 ```
 {{% /tab %}}
+
+{{% tab name="java" %}}
+```java
+@JvmStatic
+    public static TransactionBuilder generateIssue(PartyAndReference issuance,Amount<Issued<Currency>> faceValue, Instant maturityDate, Party notary){
+        CommercialPaper.State state = new CommercialPaper.State(issuance, issuance.getParty(), faceValue, maturityDate);
+        TransactionBuilder txBuilder = new TransactionBuilder(notary).withItems(
+                new StateAndContract(state,CommercialPaper.CP_PROGRAM_ID),
+                new Command(new CommercialPaper.Commands.Issue(), issuance.getParty().getOwningKey()));
+        return txBuilder;
+    }
+
+```
+{{% /tab %}}
 {{< /tabs >}}
 
 You take a reference that points to the issuing party (that is, the caller) and which can contain any internal
@@ -695,7 +709,7 @@ The function we define creates a `CommercialPaper.State` object that mostly just
 but it fills out the owner field of the state to be the same public key as the issuing party.
 
 We then combine the `CommercialPaper.State` object with a reference to the `CommercialPaper` contract, which is
-defined inside the contract itself
+defined inside the contract itself.
 
 {{< tabs name="tabs-9" >}}
 {{% tab name="kotlin" %}}
@@ -753,6 +767,18 @@ fun generateMove(tx: TransactionBuilder, paper: StateAndRef<State>, newOwner: Ab
 ```
 {{% /tab %}}
 
+{{% tab name="java" %}}
+```java
+@JvmStatic
+    public static void generateMove(TransactionBuilder tx, StateAndRef<CommercialPaper.State> paper, AbstractParty newOwner){
+        tx.addInputState(paper);
+        tx.addOutputState(paper.getState().getData().withOwner(newOwner),CommercialPaper.CP_PROGRAM_ID);
+        tx.addCommand(new CommercialPaper.Commands.Move(), paper.getState().getData().getOwner().getOwningKey());
+    }
+
+```
+{{% /tab %}}
+
 {{< /tabs >}}
 
 Here, the method takes a pre-existing `TransactionBuilder` and adds to it. This is correct because typically
@@ -786,6 +812,20 @@ fun generateRedeem(tx: TransactionBuilder, paper: StateAndRef<State>, services: 
     tx.addInputState(paper)
     tx.addCommand(Command(Commands.Redeem(), paper.state.data.owner.owningKey))
 }
+
+```
+{{% /tab %}}
+
+{{% tab name="java" %}}
+```java
+@Throws(InsufficientBalanceException::class)
+    @JvmStatic
+    public static void generateRedeem(TransactionBuilder tx, StateAndRef<CommercialPaper.State> paper, ServiceHub services, PartyAndCertificate ourIdentity ){
+        // Add the cash movement using the states in our vault.
+        CashUtils.generateSpend(services, tx, paper.getState().getData().getFaceValue().withoutIssuer(), ourIdentity, paper.getState().getData().getOwner());
+        tx.addInputState(paper);
+        tx.addCommand(new CommercialPaper.Commands.Redeem(), paper.getState().getData().getOwner().getOwningKey());
+    }
 
 ```
 {{% /tab %}}
@@ -826,6 +866,7 @@ The `CollectSignaturesFlow` provides a generic implementation of this process th
 You can see how transactions flow through the different stages of construction by examining the commercial paper
 unit tests.
 
+The generation API can be used in either a contract or a flow, depending on the specific use cases. Implementing the generation API in the contracts allows each of the participants to have a copy of the API, whereas implementing it in the flows allows for more flexibility on who will get the API.
 
 ## Constructing and transmitting multi-party transactions
 
@@ -882,55 +923,48 @@ The encumbrance reference is optional in the `ContractState` interface:
 {{< tabs name="tabs-12" >}}
 {{% tab name="kotlin" %}}
 ```kotlin
-val encumbrance: Int? get() = null
+// Full cycle example with 4 elements 0 -> 1, 1 -> 2, 2 -> 3 and 3 -> 0
+// All 3 Cash states and the TimeLock are linked and should be consumed in the same transaction.
+// Note that all of the Cash states are encumbered both together and with time lock.
+ledgerServices.ledger(DUMMY_NOTARY) {
+  transaction {
+    attachments(Cash.PROGRAM_ID, TEST_TIMELOCK_ID)
+    input(Cash.PROGRAM_ID, extraCashState)
+    output(Cash.PROGRAM_ID, "state encumbered by state 1", encumbrance = 1, contractState = stateWithNewOwner)
+    output(Cash.PROGRAM_ID, "state encumbered by state 2", encumbrance = 2, contractState = stateWithNewOwner)
+    output(Cash.PROGRAM_ID, "state encumbered by state 3", encumbrance = 3, contractState = stateWithNewOwner)
+    output(TEST_TIMELOCK_ID, "5pm time-lock", 0, timeLock)
+    command(MEGA_CORP.owningKey, Cash.Commands.Move())
+    verifies()
+  }
+}
 ```
 {{% /tab %}}
 
 {{% tab name="java" %}}
 ```java
-@Nullable
-@Override
-public Integer getEncumbrance() {
+// Full cycle example with 4 elements 0 -> 1, 1 -> 2, 2 -> 3 and 3 -> 0
+// All 3 Cash states and the TimeLock are linked and should be consumed in the same transaction.
+// Note that all of the Cash states are encumbered both together and with time lock.
+ledger(ledgerServices, l -> {
+  l.transaction(tx -> {
+    tx.attachment(Cash.PROGRAM_ID, TEST_TIMELOCK_ID);
+    tx.input(Cash.PROGRAM_ID, extraCashState);
+    tx.output(Cash.PROGRAM_ID, "state encumbered by state 1", 1, stateWithNewOwner);
+    tx.output(Cash.PROGRAM_ID, "state encumbered by state 2", 2, stateWithNewOwner);
+    tx.output(Cash.PROGRAM_ID, "state encumbered by state 3", 3, stateWithNewOwner);
+    tx.output(TEST_TIMELOCK_ID, "5pm time-lock", 0, timeLock);
+    tx.command(MEGA_CORP.getOwningKey(), new Cash.Commands.Move());
+    tx.verifies();
     return null;
-}
+  });
+  return null;
+});
 ```
 {{% /tab %}}
 
 {{< /tabs >}}
 
-The time-lock contract mentioned above can be implemented very simply:
-
-{{< tabs name="tabs-13" >}}
-{{% tab name="kotlin" %}}
-```kotlin
-class TestTimeLock : Contract {
-    ...
-    override fun verify(tx: LedgerTransaction) {
-        val time = tx.timeWindow?.untilTime ?: throw IllegalStateException(...)
-        ...
-        requireThat {
-            "the time specified in the time-lock has passed" by
-                    (time >= tx.inputs.filterIsInstance<TestTimeLock.State>().single().validFrom)
-        }
-    }
-    ...
-}
-```
-{{% /tab %}}
-
-{{< /tabs >}}
-
-We can then set up an encumbered state:
-
-{{< tabs name="tabs-14" >}}
-{{% tab name="kotlin" %}}
-```kotlin
-val encumberedState = Cash.State(amount = 1000.DOLLARS `issued by` defaultIssuer, owner = DUMMY_PUBKEY_1, encumbrance = 1)
-val fourPmTimelock = TestTimeLock.State(Instant.parse("2015-04-17T16:00:00.00Z"))
-```
-{{% /tab %}}
-
-{{< /tabs >}}
 
 When we construct a transaction that generates the encumbered state, we must place the encumbrance in the corresponding output
 position of that transaction. And when we subsequently consume that encumbered state, the same encumbrance state must be

--- a/content/en/docs/corda-os/4.7/tutorial-contract.md
+++ b/content/en/docs/corda-os/4.7/tutorial-contract.md
@@ -922,7 +922,9 @@ being consumed must have its encumbrance consumed in the same transaction, other
 
 The encumbrance reference is optional in the `ContractState` interface:
 
+{{< note >}}
 If you're using Java, you may want to add this jar to your gradle dependencies for this code example to compile.  
+{{< /note >}}
 
 ```
 cordaCompile "$corda_release_group:corda-finance-contracts:$corda_release_version"

--- a/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
+++ b/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
@@ -31,50 +31,162 @@ of digitally signed, de-duplicated reports useful for later processing.
 
 ## Adding support for observer nodes
 
-Adding support for observer nodes to your application is easy. The [IRS (interest rate swap) demo](https://github.com/corda/corda/blob/release/os/4.7/samples/irs-demo/cordapp/contracts-irs/src/main/kotlin/net/corda/irs/contract/IRS.kt) shows to do it.
+Adding support for observer nodes to your application is easy. The Trade reporting demo ([Kotlin](https://github.com/corda/samples-kotlin/tree/master/Features/observableStates-tradereporting), [Java](https://github.com/corda/samples-java/tree/master/Features/observablestates-tradereporting)) shows how to do so.
 
 Just define a new flow that wraps the `SendTransactionFlow/ReceiveTransactionFlow`, as follows:
 
 {{< tabs name="tabs-1" >}}
-{{% tab name="kotlin" %}}
+{{< tab name="kotlin" >}}
 ```kotlin
-    @InitiatedBy(Requester::class)
-    class AutoOfferAcceptor(otherSideSession: FlowSession) : Acceptor(otherSideSession) {
-        @Suspendable
-        override fun call(): SignedTransaction {
-            val finalTx = super.call()
-            // Our transaction is now committed to the ledger, so report it to our regulator. We use a custom flow
-            // that wraps SendTransactionFlow to allow the receiver to customise how ReceiveTransactionFlow is run,
-            // and because in a real life app you'd probably have more complex logic here e.g. describing why the report
-            // was filed, checking that the reportee is a regulated entity and not some random node from the wrong
-            // country and so on.
-            val regulator = serviceHub.identityService.partiesFromName("Regulator", true).single()
-            subFlow(ReportToRegulatorFlow(regulator, finalTx))
-            return finalTx
-        }
+@InitiatingFlow
+@StartableByRPC
+class TradeAndReport(val buyer: Party, val stateRegulator: Party, val nationalRegulator: Party) : FlowLogic<Unit>() {
+    override val progressTracker = ProgressTracker()
+
+    @Suspendable
+    override fun call() {
+        // Obtain a reference from a notary we wish to use.
+        /**
+         *  METHOD 1: Take first notary on network, WARNING: use for test, non-prod environments, and single-notary networks only!*
+         *  METHOD 2: Explicit selection of notary by CordaX500Name - argument can by coded in flow or parsed from config (Preferred)
+         *
+         *  * - For production you always want to use Method 2 as it guarantees the expected notary is returned.
+         */
+        val notary = serviceHub.networkMapCache.notaryIdentities.single() // METHOD 1
+        // val notary = serviceHub.networkMapCache.getNotary(CordaX500Name.parse("O=Notary,L=London,C=GB")) // METHOD 2
+
+        val transactionBuilder = TransactionBuilder(notary)
+                .addOutputState(HighlyRegulatedState(buyer, ourIdentity), HighlyRegulatedContract.ID)
+                .addCommand(HighlyRegulatedContract.Commands.Trade(), ourIdentity.owningKey)
+
+        val signedTransaction = serviceHub.signInitialTransaction(transactionBuilder)
+
+        val sessions = listOf(initiateFlow(buyer), initiateFlow(stateRegulator))
+        // We distribute the transaction to both the buyer and the state regulator using `FinalityFlow`.
+        subFlow(FinalityFlow(signedTransaction, sessions))
+
+        // We also distribute the transaction to the national regulator manually.
+        subFlow(ReportManually(signedTransaction, nationalRegulator))
+    }
+}
+
+@InitiatingFlow
+class ReportManually(val signedTransaction: SignedTransaction, val regulator: Party) : FlowLogic<Unit>() {
+    override val progressTracker = ProgressTracker()
+
+    @Suspendable
+    override fun call() {
+        val session = initiateFlow(regulator)
+        session.send(signedTransaction)
+    }
+}
+
+@InitiatedBy(ReportManually::class)
+class ReportManuallyResponder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        val signedTransaction = counterpartySession.receive<SignedTransaction>().unwrap { it }
+        // The national regulator records all of the transaction's states using
+        // `recordTransactions` with the `ALL_VISIBLE` flag.
+        serviceHub.recordTransactions(StatesToRecord.ALL_VISIBLE, listOf(signedTransaction))
+    }
+}
+
+{{< /tab >}}
+
+
+{{< tab name="java" >}}
+```java
+@InitiatingFlow
+@StartableByRPC
+public class TradeAndReport extends FlowLogic<Void> {
+
+    private final Party buyer;
+    private final Party stateRegulator;
+    private final Party nationalRegulator;
+
+    public TradeAndReport(Party buyer, Party stateRegulator, Party nationalRegulator) {
+        this.buyer = buyer;
+        this.stateRegulator = stateRegulator;
+        this.nationalRegulator = nationalRegulator;
     }
 
-    @InitiatingFlow
-    class ReportToRegulatorFlow(private val regulator: Party, private val finalTx: SignedTransaction) : FlowLogic<Unit>() {
-        @Suspendable
-        override fun call() {
-            val session = initiateFlow(regulator)
-            subFlow(SendTransactionFlow(session, finalTx))
-        }
+    @Suspendable
+    @Override
+    public Void call() throws FlowException {
+
+        // Obtain a reference to a notary we wish to use.
+        /** METHOD 1: Take first notary on network, WARNING: use for test, non-prod environments, and single-notary networks only!*
+         *  METHOD 2: Explicit selection of notary by CordaX500Name - argument can by coded in flow or parsed from config (Preferred)
+         *
+         *  * - For production you always want to use Method 2 as it guarantees the expected notary is returned.
+         */
+        final Party notary = getServiceHub().getNetworkMapCache().getNotaryIdentities().get(0); // METHOD 1
+        // final Party notary = getServiceHub().getNetworkMapCache().getNotary(CordaX500Name.parse("O=Notary,L=London,C=GB")); // METHOD 2
+
+        HighlyRegulatedState outputState = new HighlyRegulatedState(buyer, getOurIdentity());
+
+        TransactionBuilder transactionBuilder = new TransactionBuilder(notary)
+                .addOutputState(outputState, HighlyRegulatedContract.ID)
+                .addCommand(new HighlyRegulatedContract.Commands.Trade(), getOurIdentity().getOwningKey());
+
+        SignedTransaction signedTransaction = getServiceHub().signInitialTransaction(transactionBuilder);
+
+        List<FlowSession> sessions = ImmutableList.of(initiateFlow(buyer), initiateFlow(stateRegulator));
+        // We distribute the transaction to both the buyer and the state regulator using `FinalityFlow`.
+        subFlow(new FinalityFlow(signedTransaction, sessions));
+
+        // We also distribute the transaction to the national regulator manually.
+        subFlow(new ReportManually(signedTransaction, nationalRegulator));
+
+        return null;
+    }
+}
+
+@InitiatingFlow
+public class ReportManually extends FlowLogic<Void> {
+    private final ProgressTracker progressTracker = new ProgressTracker();
+    private final SignedTransaction signedTransaction;
+    private final Party regulator;
+
+    public ReportManually(SignedTransaction signedTransaction, Party regulator) {
+        this.signedTransaction = signedTransaction;
+        this.regulator = regulator;
     }
 
-    @InitiatedBy(ReportToRegulatorFlow::class)
-    class ReceiveRegulatoryReportFlow(private val otherSideSession: FlowSession) : FlowLogic<Unit>() {
-        @Suspendable
-        override fun call() {
-            // Start the matching side of SendTransactionFlow above, but tell it to record all visible states even
-            // though they (as far as the node can tell) are nothing to do with us.
-            subFlow(ReceiveTransactionFlow(otherSideSession, true, StatesToRecord.ALL_VISIBLE))
-        }
+    @Override
+    public ProgressTracker getProgressTracker() {
+        return progressTracker;
     }
 
-```
-{{% /tab %}}
+    @Suspendable
+    @Override
+    public Void call() throws FlowException {
+        FlowSession session = initiateFlow(regulator);
+        session.send(signedTransaction);
+        return null;
+    }
+}
+
+@InitiatedBy(ReportManually.class)
+public class ReportManuallyResponder extends FlowLogic<Void> {
+    private final FlowSession counterpartySession;
+
+    public ReportManuallyResponder(FlowSession counterpartySession) {
+        this.counterpartySession = counterpartySession;
+    }
+
+    @Suspendable
+    @Override
+    public Void call() throws FlowException {
+        SignedTransaction signedTransaction = counterpartySession.receive(SignedTransaction.class).unwrap(it -> it);
+        // The national regulator records all of the transaction's states using
+        // `recordTransactions` with the `ALL_VISIBLE` flag.
+        getServiceHub().recordTransactions(StatesToRecord.ALL_VISIBLE, ImmutableList.of(signedTransaction));
+        return null;
+    }
+}
+{{< /tab >}}
 
 {{< /tabs >}}
 

--- a/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
+++ b/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
@@ -91,7 +91,7 @@ class ReportManuallyResponder(val counterpartySession: FlowSession) : FlowLogic<
         serviceHub.recordTransactions(StatesToRecord.ALL_VISIBLE, listOf(signedTransaction))
     }
 }
-
+```
 {{< /tab >}}
 
 
@@ -186,6 +186,7 @@ public class ReportManuallyResponder extends FlowLogic<Void> {
         return null;
     }
 }
+```
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
+++ b/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
@@ -33,8 +33,6 @@ of digitally signed, de-duplicated reports useful for later processing.
 
 Adding support for observer nodes to your application is easy. The Trade reporting demo ([Kotlin](https://github.com/corda/samples-kotlin/tree/master/Features/observableStates-tradereporting), [Java](https://github.com/corda/samples-java/tree/master/Features/observablestates-tradereporting)) shows how to do so.
 
-Just define a new flow that wraps the `SendTransactionFlow/ReceiveTransactionFlow`, as follows:
-
 {{< tabs name="tabs-1" >}}
 {{< tab name="kotlin" >}}
 ```kotlin

--- a/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
+++ b/content/en/docs/corda-os/4.7/tutorial-observer-nodes.md
@@ -189,24 +189,6 @@ public class ReportManuallyResponder extends FlowLogic<Void> {
 
 {{< /tabs >}}
 
-
-[AutoOfferFlow.kt](https://github.com/corda/corda/blob/release/os/4.7/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/AutoOfferFlow.kt)
-
-In this example, the `AutoOfferFlow` is the business logic, and we define two very short and simple flows to send
-the transaction to the regulator. There are two important aspects to note here:
-
-
-* The `ReportToRegulatorFlow` is marked as an `@InitiatingFlow` because it will start a new conversation, context
-free, with the regulator.
-* The `ReceiveRegulatoryReportFlow` uses `ReceiveTransactionFlow` in a special way - it tells it to send the
-transaction to the vault for processing, including all states even if not involving our public keys. This is required
-because otherwise the vault will ignore states that don’t list any of the node’s public keys, but in this case,
-we do want to passively observe states we can’t change. So overriding this behaviour is required.
-
-If the states define a relational mapping (see [API: Persistence](api-persistence.md)) then the regulator will be able to query the
-reports from their database and observe new transactions coming in via RPC.
-
-
 ## How observer nodes operate
 
 * By default, vault queries do not differentiate between states you recorded as a participant/owner, and states you


### PR DESCRIPTION
Raising this PR to add missing code snippets in OS 4.7 tutorials. 

@peterli-r3 , in `tutorial-observer-nodes.md` under the "Adding support for observer nodes" section can you look closely at the last paragraphs following the code snippets? The sample linked there should be removed, and the text doesn't apply either, but would it make sense to update this text to provide descriptions/explanation of the flows in the new code snippets? 
