### PR TITLE
EG-4668: Changed BIAB guide name to How-to guide in all instances.

### DIFF
--- a/content/en/docs/apps/bankinabox/user-interface/how-to.md
+++ b/content/en/docs/apps/bankinabox/user-interface/how-to.md
@@ -7,11 +7,11 @@ menu:
 tags:
 - Bank in a Box
 - UI
-title: How to guide
+title: How-to guide
 weight: 300
 ---
 
-# How to guide
+# How-to guide
 
 When using the Bank in a Box application, you will be able to perform different tasks depending on your user role.
 

--- a/content/en/docs/apps/bankinabox/user-interface/user-interface.md
+++ b/content/en/docs/apps/bankinabox/user-interface/user-interface.md
@@ -19,4 +19,4 @@ The user interface on Bank in a Box provides an easy to use solution based on [R
 
 * [Admin user interface](admin-ui-guide.md)
 * [Customer and guest user interface](customer-ui-guide.md)
-* [How to guide](how-to.md)
+* [How-to guide](how-to.md)

--- a/themes/hugo-r3-theme/layouts/index.html
+++ b/themes/hugo-r3-theme/layouts/index.html
@@ -739,7 +739,7 @@
 
         <li><a href=
         "docs/apps/bankinabox/user-interface/how-to.html">
-        How to guide</a></li>
+        How-to guide</a></li>
 
         <li><a href=
         "docs/apps/bankinabox/api-guide.html">


### PR DESCRIPTION
Previously this was "How to guide", corrected to "How-to guide" according to Microsoft style guide. 