### PR TITLE
EG-4699: Added some missing steps, examples, updated version numbers listed.

### DIFF
--- a/content/en/docs/corda-os/4.4/building-the-docs.md
+++ b/content/en/docs/corda-os/4.4/building-the-docs.md
@@ -29,13 +29,14 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
+2. If you've already installed Hugo, check your version. If the result is not `v0.65` or later, or if you don't see `Extended`, you'll need to download the latest extended version of [Hugo](https://github.com/gohugoio/hugo/releases) (for example, `hugo_extended_0.74.3_Linux-64bit.tar.gz`).
 3. Ensure the Hugo binary is on your `PATH`.
 4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
-5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`.
-7. Open the local docs site built on [http://localhost:1313](http://localhost:1313) in your browser.
-8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
+5. Clone your fork locally.
+6. Open a console / command prompt window and navigate (`cd`) to the root directory of the fork repo.
+7. Run `hugo serve`.
+8. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
+9. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
 ## Contribute to documentation updates
 
@@ -111,8 +112,8 @@ To best way to keep your fork in sync with the upstream (original) repository is
 To add `upstream`:
 
 ```
-$ cd <to-your-fork-repo-dir>
-$ git remote add upstream git://github.com/corda/corda-docs.git
+cd <to-your-fork-repo-dir>
+git remote add upstream git://github.com/corda/corda-docs.git
 ```
 
 You would normally only need do this once after you create the fork.
@@ -138,18 +139,18 @@ To view your remotes:
 You should see something like this:
 
 ```
-$ git remote -v
+git remote -v
 
-origin	https://github.com/ivanterziev-r3/corda-docs.git (fetch)  #  YOUR FORK
-origin	https://github.com/ivanterziev-r3/corda-docs.git (push)
-upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
-upstream	git://github.com/corda/corda-docs.git (push)
+origin	git@github.com:my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	git@github.com:my-github-username/corda-docs.git (push)
+upstream	git@github.com:corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	git@github.com:corda/corda-docs.git (push)
 ```
 
 Alternatively, if you are accessing GitHub without an `ssh` key:
 
 ```
-$ git remote -v
+git remote -v
 
 origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
 origin	https://github.com/my-github-username/corda-docs.git (push)
@@ -159,17 +160,17 @@ upstream	https://github.com/corda/corda-docs.git (push)
 
 ### Remove the upstream repo
 
-To remove the `upstream` repo:
+If you need to remove the `upstream` repo for any reason:
 
 ```
-$ git remote rm upstream
+git remote rm upstream
 ```
 
 ### Keep the upstream repo updated
 
 To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
-`$ git fetch upstream`
+`git fetch upstream`
 
 ### Sync your fork
 
@@ -179,7 +180,7 @@ There are two ways in which you can do this - `merge` or `rebase`.
 
 To sync your fork via `merge`:
 
-`$ git merge upstream/master master`
+`git merge upstream/master master`
 
 This command will merge the latest changes from the `master` branch of the upstream into your local fork’s `master` branch.
 
@@ -188,21 +189,21 @@ To merge a different branch, replace `master` with the name of that branch for b
 For example, to merge a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git merge upstream/example-branch example-branch
+git checkout example-branch
+git merge upstream/example-branch example-branch
 ```
 
 #### Rebase the upstream with your fork
 
-`$ git rebase upstream/master`
+`git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
 For example, to rebase a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git rebase upstream/example-branch example-branch
+git checkout example-branch
+git rebase upstream/example-branch example-branch
 ```
 
 #### Push from the local fork master to the origin fork master

--- a/content/en/docs/corda-os/4.4/building-the-docs.md
+++ b/content/en/docs/corda-os/4.4/building-the-docs.md
@@ -31,7 +31,7 @@ Steps:
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
 2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
 5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
 6. Run `hugo serve`.
 7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.

--- a/content/en/docs/corda-os/4.4/building-the-docs.md
+++ b/content/en/docs/corda-os/4.4/building-the-docs.md
@@ -34,7 +34,7 @@ Steps:
 4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
 5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
 6. Run `hugo serve`.
-7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
+7. Open the local docs site built on [http://localhost:1313](http://localhost:1313) in your browser.
 8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
 ## Contribute to documentation updates

--- a/content/en/docs/corda-os/4.4/building-the-docs.md
+++ b/content/en/docs/corda-os/4.4/building-the-docs.md
@@ -18,7 +18,6 @@ tags:
 title: Build the documentation
 ---
 
-
 # Build the docs
 
 The documentation source files are under the `../content` directory in the [corda-docs](https://github.com/corda/corda-docs/) repository, and is written in `markdown` format.
@@ -30,11 +29,11 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest version, otherwise at least v0.65.
+2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository.
-5. In command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
+5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
+6. Run `hugo serve`.
 7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
 8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
@@ -54,7 +53,7 @@ The documentation for all released versions of Corda OS, Corda Enterprise, and C
 
 For example:
 
-`../corda-docs/content/en/docs/corda-os/1.0`
+`../corda-docs/content/en/docs/corda-os/4.4`
 
 ## Edit web pages directly in Visual Studio Code
 
@@ -66,7 +65,7 @@ Windows Powershell (assuming there are no spaces in your directory names):
 
 Mac/Linux:
 
-`make local-serve-and-edit`  
+`make local-serve-and-edit`
 
 Or if you want to use Docker:
 
@@ -74,7 +73,7 @@ Or if you want to use Docker:
 
 As a result, there will be an extra icon in the title bar of your local docs site, which should open the current page in Visual Studio Code:
 
-![Visual Studio Code](/en/images/hugo-vscode-page-edit.png "Visual Studio Code")
+{{< figure alt="Visual Studio Code" zoom="/en/images/hugo-vscode-page-edit.png" >}}
 
 ## Edit web pages directly in Atom
 
@@ -118,6 +117,18 @@ $ git remote add upstream git://github.com/corda/corda-docs.git
 
 You would normally only need do this once after you create the fork.
 
+If you are not using an `ssh` key to access GitHub, use the `https` URL instead:
+
+```
+git remote add upstream https://github.com/corda/corda-docs.git
+```
+
+If you’ve got the upstream repo URL wrong, you can change the upstream repo URL using the following command:
+
+```
+git remote set-url upstream https://github.com/corda/corda-docs.git
+```
+
 ### View your remotes
 
 To view your remotes:
@@ -135,19 +146,38 @@ upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
 upstream	git://github.com/corda/corda-docs.git (push)
 ```
 
+Alternatively, if you are accessing GitHub without an `ssh` key:
+
+```
+$ git remote -v
+
+origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	https://github.com/my-github-username/corda-docs.git (push)
+upstream	https://github.com/corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	https://github.com/corda/corda-docs.git (push)
+```
+
+### Remove the upstream repo
+
+To remove the `upstream` repo:
+
+```
+$ git remote rm upstream
+```
+
 ### Keep the upstream repo updated
 
-To keep the upstream updated (in other words, to fetch all the stuff from the upstream repo):
+To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
 `$ git fetch upstream`
 
 ### Sync your fork
 
-There are two ways in which you can do this - merge or rebase.
+There are two ways in which you can do this - `merge` or `rebase`.
 
 #### Merge the upstream with your fork
 
-To sync your fork via merge:
+To sync your fork via `merge`:
 
 `$ git merge upstream/master master`
 
@@ -155,18 +185,30 @@ This command will merge the latest changes from the `master` branch of the upstr
 
 To merge a different branch, replace `master` with the name of that branch for both repos.
 
+For example, to merge a branch called `example-branch`, run the following:
+
+```
+$ git checkout example-branch
+$ git merge upstream/example-branch example-branch
+```
+
 #### Rebase the upstream with your fork
 
 `$ git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
-{{< note >}}
+For example, to rebase a branch called `example-branch`, run the following:
 
-After the merge or rebase, don’t forget to push your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
+```
+$ git checkout example-branch
+$ git rebase upstream/example-branch example-branch
+```
+
+#### Push from the local fork master to the origin fork master
+
+After the `merge` or `rebase`, don’t forget to `push` your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
 
 For example:
 
 `git push origin master`
-
-{{< /note >}}

--- a/content/en/docs/corda-os/4.5/building-the-docs.md
+++ b/content/en/docs/corda-os/4.5/building-the-docs.md
@@ -26,13 +26,14 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
+2. If you've already installed Hugo, check your version. If the result is not `v0.65` or later, or if you don't see `Extended`, you'll need to download the latest extended version of [Hugo](https://github.com/gohugoio/hugo/releases) (for example, `hugo_extended_0.74.3_Linux-64bit.tar.gz`).
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
-5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`.
-7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
-8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
+5. Clone your fork locally.
+6. Open a console / command prompt window and navigate (`cd`) to the root directory of the fork repo.
+7. Run `hugo serve`.
+8. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
+9. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
 ## Contribute to documentation updates
 
@@ -108,8 +109,8 @@ To best way to keep your fork in sync with the upstream (original) repository is
 To add `upstream`:
 
 ```
-$ cd <to-your-fork-repo-dir>
-$ git remote add upstream git://github.com/corda/corda-docs.git
+cd <to-your-fork-repo-dir>
+git remote add upstream git://github.com/corda/corda-docs.git
 ```
 
 You would normally only need do this once after you create the fork.
@@ -135,18 +136,18 @@ To view your remotes:
 You should see something like this:
 
 ```
-$ git remote -v
+git remote -v
 
-origin	https://github.com/ivanterziev-r3/corda-docs.git (fetch)  #  YOUR FORK
-origin	https://github.com/ivanterziev-r3/corda-docs.git (push)
-upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
-upstream	git://github.com/corda/corda-docs.git (push)
+origin	git@github.com:my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	git@github.com:my-github-username/corda-docs.git (push)
+upstream	git@github.com:corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	git@github.com:corda/corda-docs.git (push)
 ```
 
 Alternatively, if you are accessing GitHub without an `ssh` key:
 
 ```
-$ git remote -v
+git remote -v
 
 origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
 origin	https://github.com/my-github-username/corda-docs.git (push)
@@ -156,17 +157,17 @@ upstream	https://github.com/corda/corda-docs.git (push)
 
 ### Remove the upstream repo
 
-To remove the `upstream` repo:
+If you need to remove the `upstream` repo for any reason:
 
 ```
-$ git remote rm upstream
+git remote rm upstream
 ```
 
 ### Keep the upstream repo updated
 
 To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
-`$ git fetch upstream`
+`git fetch upstream`
 
 ### Sync your fork
 
@@ -176,7 +177,7 @@ There are two ways in which you can do this - `merge` or `rebase`.
 
 To sync your fork via `merge`:
 
-`$ git merge upstream/master master`
+`git merge upstream/master master`
 
 This command will merge the latest changes from the `master` branch of the upstream into your local fork’s `master` branch.
 
@@ -185,21 +186,21 @@ To merge a different branch, replace `master` with the name of that branch for b
 For example, to merge a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git merge upstream/example-branch example-branch
+git checkout example-branch
+git merge upstream/example-branch example-branch
 ```
 
 #### Rebase the upstream with your fork
 
-`$ git rebase upstream/master`
+`git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
 For example, to rebase a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git rebase upstream/example-branch example-branch
+git checkout example-branch
+git rebase upstream/example-branch example-branch
 ```
 
 #### Push from the local fork master to the origin fork master

--- a/content/en/docs/corda-os/4.5/building-the-docs.md
+++ b/content/en/docs/corda-os/4.5/building-the-docs.md
@@ -26,11 +26,11 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest version, otherwise at least v0.65.
+2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository.
-5. In command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
+5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
+6. Run `hugo serve`.
 7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
 8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
@@ -50,7 +50,7 @@ The documentation for all released versions of Corda OS, Corda Enterprise, and C
 
 For example:
 
-`../corda-docs/content/en/docs/corda-os/1.0`
+`../corda-docs/content/en/docs/corda-os/4.5`
 
 ## Edit web pages directly in Visual Studio Code
 
@@ -62,7 +62,7 @@ Windows Powershell (assuming there are no spaces in your directory names):
 
 Mac/Linux:
 
-`make local-serve-and-edit`  
+`make local-serve-and-edit`
 
 Or if you want to use Docker:
 
@@ -70,7 +70,7 @@ Or if you want to use Docker:
 
 As a result, there will be an extra icon in the title bar of your local docs site, which should open the current page in Visual Studio Code:
 
-![Visual Studio Code](/en/images/hugo-vscode-page-edit.png "Visual Studio Code")
+{{< figure alt="Visual Studio Code" zoom="/en/images/hugo-vscode-page-edit.png" >}}
 
 ## Edit web pages directly in Atom
 
@@ -114,6 +114,18 @@ $ git remote add upstream git://github.com/corda/corda-docs.git
 
 You would normally only need do this once after you create the fork.
 
+If you are not using an `ssh` key to access GitHub, use the `https` URL instead:
+
+```
+git remote add upstream https://github.com/corda/corda-docs.git
+```
+
+If you’ve got the upstream repo URL wrong, you can change the upstream repo URL using the following command:
+
+```
+git remote set-url upstream https://github.com/corda/corda-docs.git
+```
+
 ### View your remotes
 
 To view your remotes:
@@ -131,19 +143,38 @@ upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
 upstream	git://github.com/corda/corda-docs.git (push)
 ```
 
+Alternatively, if you are accessing GitHub without an `ssh` key:
+
+```
+$ git remote -v
+
+origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	https://github.com/my-github-username/corda-docs.git (push)
+upstream	https://github.com/corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	https://github.com/corda/corda-docs.git (push)
+```
+
+### Remove the upstream repo
+
+To remove the `upstream` repo:
+
+```
+$ git remote rm upstream
+```
+
 ### Keep the upstream repo updated
 
-To keep the upstream updated (in other words, to fetch all the stuff from the upstream repo):
+To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
 `$ git fetch upstream`
 
 ### Sync your fork
 
-There are two ways in which you can do this - merge or rebase.
+There are two ways in which you can do this - `merge` or `rebase`.
 
 #### Merge the upstream with your fork
 
-To sync your fork via merge:
+To sync your fork via `merge`:
 
 `$ git merge upstream/master master`
 
@@ -151,18 +182,30 @@ This command will merge the latest changes from the `master` branch of the upstr
 
 To merge a different branch, replace `master` with the name of that branch for both repos.
 
+For example, to merge a branch called `example-branch`, run the following:
+
+```
+$ git checkout example-branch
+$ git merge upstream/example-branch example-branch
+```
+
 #### Rebase the upstream with your fork
 
 `$ git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
-{{< note >}}
+For example, to rebase a branch called `example-branch`, run the following:
 
-After the merge or rebase, don’t forget to push your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
+```
+$ git checkout example-branch
+$ git rebase upstream/example-branch example-branch
+```
+
+#### Push from the local fork master to the origin fork master
+
+After the `merge` or `rebase`, don’t forget to `push` your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
 
 For example:
 
 `git push origin master`
-
-{{< /note >}}

--- a/content/en/docs/corda-os/4.6/building-the-docs.md
+++ b/content/en/docs/corda-os/4.6/building-the-docs.md
@@ -26,11 +26,11 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest version, otherwise at least v0.65.
+2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository.
-5. In command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
+5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
+6. Run `hugo serve`.
 7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
 8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
@@ -50,7 +50,7 @@ The documentation for all released versions of Corda OS, Corda Enterprise, and C
 
 For example:
 
-`../corda-docs/content/en/docs/corda-os/1.0`
+`../corda-docs/content/en/docs/corda-os/4.6`
 
 ## Edit web pages directly in Visual Studio Code
 
@@ -114,6 +114,18 @@ $ git remote add upstream git://github.com/corda/corda-docs.git
 
 You would normally only need do this once after you create the fork.
 
+If you are not using an `ssh` key to access GitHub, use the `https` URL instead:
+
+```
+git remote add upstream https://github.com/corda/corda-docs.git
+```
+
+If you’ve got the upstream repo URL wrong, you can change the upstream repo URL using the following command:
+
+```
+git remote set-url upstream https://github.com/corda/corda-docs.git
+```
+
 ### View your remotes
 
 To view your remotes:
@@ -131,19 +143,38 @@ upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
 upstream	git://github.com/corda/corda-docs.git (push)
 ```
 
+Alternatively, if you are accessing GitHub without an `ssh` key:
+
+```
+$ git remote -v
+
+origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	https://github.com/my-github-username/corda-docs.git (push)
+upstream	https://github.com/corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	https://github.com/corda/corda-docs.git (push)
+```
+
+### Remove the upstream repo
+
+To remove the `upstream` repo:
+
+```
+$ git remote rm upstream
+```
+
 ### Keep the upstream repo updated
 
-To keep the upstream updated (in other words, to fetch all the stuff from the upstream repo):
+To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
 `$ git fetch upstream`
 
 ### Sync your fork
 
-There are two ways in which you can do this - merge or rebase.
+There are two ways in which you can do this - `merge` or `rebase`.
 
 #### Merge the upstream with your fork
 
-To sync your fork via merge:
+To sync your fork via `merge`:
 
 `$ git merge upstream/master master`
 
@@ -151,18 +182,30 @@ This command will merge the latest changes from the `master` branch of the upstr
 
 To merge a different branch, replace `master` with the name of that branch for both repos.
 
+For example, to merge a branch called `example-branch`, run the following:
+
+```
+$ git checkout example-branch
+$ git merge upstream/example-branch example-branch
+```
+
 #### Rebase the upstream with your fork
 
 `$ git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
-{{< note >}}
+For example, to rebase a branch called `example-branch`, run the following:
 
-After the merge or rebase, don’t forget to push your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
+```
+$ git checkout example-branch
+$ git rebase upstream/example-branch example-branch
+```
+
+#### Push from the local fork master to the origin fork master
+
+After the `merge` or `rebase`, don’t forget to `push` your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
 
 For example:
 
 `git push origin master`
-
-{{< /note >}}

--- a/content/en/docs/corda-os/4.6/building-the-docs.md
+++ b/content/en/docs/corda-os/4.6/building-the-docs.md
@@ -26,13 +26,14 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
+2. If you've already installed Hugo, check your version. If the result is not `v0.65` or later, or if you don't see `Extended`, you'll need to download the latest extended version of [Hugo](https://github.com/gohugoio/hugo/releases) (for example, `hugo_extended_0.74.3_Linux-64bit.tar.gz`).
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
-5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`.
-7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
-8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
+5. Clone your fork locally.
+6. Open a console / command prompt window and navigate (`cd`) to the root directory of the fork repo.
+7. Run `hugo serve`.
+8. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
+9. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
 ## Contribute to documentation updates
 
@@ -108,8 +109,8 @@ To best way to keep your fork in sync with the upstream (original) repository is
 To add `upstream`:
 
 ```
-$ cd <to-your-fork-repo-dir>
-$ git remote add upstream git://github.com/corda/corda-docs.git
+cd <to-your-fork-repo-dir>
+git remote add upstream git://github.com/corda/corda-docs.git
 ```
 
 You would normally only need do this once after you create the fork.
@@ -135,18 +136,18 @@ To view your remotes:
 You should see something like this:
 
 ```
-$ git remote -v
+git remote -v
 
-origin	https://github.com/ivanterziev-r3/corda-docs.git (fetch)  #  YOUR FORK
-origin	https://github.com/ivanterziev-r3/corda-docs.git (push)
-upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
-upstream	git://github.com/corda/corda-docs.git (push)
+origin	git@github.com:my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	git@github.com:my-github-username/corda-docs.git (push)
+upstream	git@github.com:corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	git@github.com:corda/corda-docs.git (push)
 ```
 
 Alternatively, if you are accessing GitHub without an `ssh` key:
 
 ```
-$ git remote -v
+git remote -v
 
 origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
 origin	https://github.com/my-github-username/corda-docs.git (push)
@@ -156,17 +157,17 @@ upstream	https://github.com/corda/corda-docs.git (push)
 
 ### Remove the upstream repo
 
-To remove the `upstream` repo:
+If you need to remove the `upstream` repo for any reason:
 
 ```
-$ git remote rm upstream
+git remote rm upstream
 ```
 
 ### Keep the upstream repo updated
 
 To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
-`$ git fetch upstream`
+`git fetch upstream`
 
 ### Sync your fork
 
@@ -176,7 +177,7 @@ There are two ways in which you can do this - `merge` or `rebase`.
 
 To sync your fork via `merge`:
 
-`$ git merge upstream/master master`
+`git merge upstream/master master`
 
 This command will merge the latest changes from the `master` branch of the upstream into your local fork’s `master` branch.
 
@@ -185,21 +186,21 @@ To merge a different branch, replace `master` with the name of that branch for b
 For example, to merge a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git merge upstream/example-branch example-branch
+git checkout example-branch
+git merge upstream/example-branch example-branch
 ```
 
 #### Rebase the upstream with your fork
 
-`$ git rebase upstream/master`
+`git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
 For example, to rebase a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git rebase upstream/example-branch example-branch
+git checkout example-branch
+git rebase upstream/example-branch example-branch
 ```
 
 #### Push from the local fork master to the origin fork master

--- a/content/en/docs/corda-os/4.7/building-the-docs.md
+++ b/content/en/docs/corda-os/4.7/building-the-docs.md
@@ -26,13 +26,14 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
+2. If you've already installed Hugo, check your version. If the result is not `v0.65` or later, or if you don't see `Extended`, you'll need to download the latest extended version of [Hugo](https://github.com/gohugoio/hugo/releases) (for example, `hugo_extended_0.74.3_Linux-64bit.tar.gz`).
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
-5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`.
-7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
-8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and ensure it is added as the upstream remote in your fork.
+5. Clone your fork locally.
+6. Open a console / command prompt window and navigate (`cd`) to the root directory of the fork repo.
+7. Run `hugo serve`.
+8. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
+9. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
 ## Contribute to documentation updates
 
@@ -108,8 +109,8 @@ To best way to keep your fork in sync with the upstream (original) repository is
 To add `upstream`:
 
 ```
-$ cd <to-your-fork-repo-dir>
-$ git remote add upstream git://github.com/corda/corda-docs.git
+cd <to-your-fork-repo-dir>
+git remote add upstream git://github.com/corda/corda-docs.git
 ```
 
 You would normally only need do this once after you create the fork.
@@ -135,18 +136,18 @@ To view your remotes:
 You should see something like this:
 
 ```
-$ git remote -v
+git remote -v
 
-origin	https://github.com/ivanterziev-r3/corda-docs.git (fetch)  #  YOUR FORK
-origin	https://github.com/ivanterziev-r3/corda-docs.git (push)
-upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
-upstream	git://github.com/corda/corda-docs.git (push)
+origin	git@github.com:my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	git@github.com:my-github-username/corda-docs.git (push)
+upstream	git@github.com:corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	git@github.com:corda/corda-docs.git (push)
 ```
 
 Alternatively, if you are accessing GitHub without an `ssh` key:
 
 ```
-$ git remote -v
+git remote -v
 
 origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
 origin	https://github.com/my-github-username/corda-docs.git (push)
@@ -156,17 +157,17 @@ upstream	https://github.com/corda/corda-docs.git (push)
 
 ### Remove the upstream repo
 
-To remove the `upstream` repo:
+If you need to remove the `upstream` repo for any reason:
 
 ```
-$ git remote rm upstream
+git remote rm upstream
 ```
 
 ### Keep the upstream repo updated
 
 To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
-`$ git fetch upstream`
+`git fetch upstream`
 
 ### Sync your fork
 
@@ -176,7 +177,7 @@ There are two ways in which you can do this - `merge` or `rebase`.
 
 To sync your fork via `merge`:
 
-`$ git merge upstream/master master`
+`git merge upstream/master master`
 
 This command will merge the latest changes from the `master` branch of the upstream into your local fork’s `master` branch.
 
@@ -185,21 +186,21 @@ To merge a different branch, replace `master` with the name of that branch for b
 For example, to merge a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git merge upstream/example-branch example-branch
+git checkout example-branch
+git merge upstream/example-branch example-branch
 ```
 
 #### Rebase the upstream with your fork
 
-`$ git rebase upstream/master`
+`git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
 For example, to rebase a branch called `example-branch`, run the following:
 
 ```
-$ git checkout example-branch
-$ git rebase upstream/example-branch example-branch
+git checkout example-branch
+git rebase upstream/example-branch example-branch
 ```
 
 #### Push from the local fork master to the origin fork master

--- a/content/en/docs/corda-os/4.7/building-the-docs.md
+++ b/content/en/docs/corda-os/4.7/building-the-docs.md
@@ -26,11 +26,11 @@ The documentation output in HTML format is generated using [Hugo](https://github
 Steps:
 
 1. Download [Visual Studio Code](https://code.visualstudio.com/) or a markdown editor of your choice ([atom](https://atom.io/), for example).
-2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest version, otherwise at least v0.65.
+2. Download [Hugo](https://github.com/gohugoio/hugo/releases). Use the latest, extended version, otherwise at least v0.65.
 3. Ensure the Hugo binary is on your `PATH`.
-4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository.
-5. In command-line, navigate (`cd`) to root of the fork repo.
-6. Run `hugo serve`
+4. Fork the [corda-docs](https://github.com/corda/corda-docs/) repository and add it as upstream.
+5. Clone your fork locally and, in command-line, navigate (`cd`) to root of the fork repo.
+6. Run `hugo serve`.
 7. Open the local docs site build on [http://localhost:1313](http://localhost:1313) (or whatever it says in the console) in your browser.
 8. Edit the documentation source files in `markdown` - all source files are in the `../content` directory in the repo structure. Each edit triggers an immediate page update on [http://localhost:1313](http://localhost:1313).
 
@@ -50,7 +50,7 @@ The documentation for all released versions of Corda OS, Corda Enterprise, and C
 
 For example:
 
-`../corda-docs/content/en/docs/corda-os/1.0`
+`../corda-docs/content/en/docs/corda-os/4.7`
 
 ## Edit web pages directly in Visual Studio Code
 
@@ -114,6 +114,18 @@ $ git remote add upstream git://github.com/corda/corda-docs.git
 
 You would normally only need do this once after you create the fork.
 
+If you are not using an `ssh` key to access GitHub, use the `https` URL instead:
+
+```
+git remote add upstream https://github.com/corda/corda-docs.git
+```
+
+If you’ve got the upstream repo URL wrong, you can change the upstream repo URL using the following command:
+
+```
+git remote set-url upstream https://github.com/corda/corda-docs.git
+```
+
 ### View your remotes
 
 To view your remotes:
@@ -131,19 +143,38 @@ upstream	git://github.com/corda/corda-docs.git (fetch)  #  THE ORIGINAL REPO
 upstream	git://github.com/corda/corda-docs.git (push)
 ```
 
+Alternatively, if you are accessing GitHub without an `ssh` key:
+
+```
+$ git remote -v
+
+origin	https://github.com/my-github-username/corda-docs.git (fetch)   # YOUR FORK
+origin	https://github.com/my-github-username/corda-docs.git (push)
+upstream	https://github.com/corda/corda-docs.git (fetch)      # THE ORIGINAL REPO
+upstream	https://github.com/corda/corda-docs.git (push)
+```
+
+### Remove the upstream repo
+
+To remove the `upstream` repo:
+
+```
+$ git remote rm upstream
+```
+
 ### Keep the upstream repo updated
 
-To keep the upstream updated (in other words, to fetch all the stuff from the upstream repo):
+To keep the upstream updated (in other words, to `fetch` all the stuff from the upstream repo):
 
 `$ git fetch upstream`
 
 ### Sync your fork
 
-There are two ways in which you can do this - merge or rebase.
+There are two ways in which you can do this - `merge` or `rebase`.
 
 #### Merge the upstream with your fork
 
-To sync your fork via merge:
+To sync your fork via `merge`:
 
 `$ git merge upstream/master master`
 
@@ -151,18 +182,30 @@ This command will merge the latest changes from the `master` branch of the upstr
 
 To merge a different branch, replace `master` with the name of that branch for both repos.
 
+For example, to merge a branch called `example-branch`, run the following:
+
+```
+$ git checkout example-branch
+$ git merge upstream/example-branch example-branch
+```
+
 #### Rebase the upstream with your fork
 
 `$ git rebase upstream/master`
 
 To rebase a different branch, replace `master` with the name of that branch for both repos.
 
-{{< note >}}
+For example, to rebase a branch called `example-branch`, run the following:
 
-After the merge or rebase, don’t forget to push your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
+```
+$ git checkout example-branch
+$ git rebase upstream/example-branch example-branch
+```
+
+#### Push from the local fork master to the origin fork master
+
+After the `merge` or `rebase`, don’t forget to `push` your local fork's master branch (or another branch you’ve synced) to the fork origin `master` (or another corresponding branch).
 
 For example:
 
 `git push origin master`
-
-{{< /note >}}


### PR DESCRIPTION
@edward-prosser , @ivanterziev-r3 Could you take a look at this PR? Updating the Build the docs page in our OS docs to reflect some missing steps and examples. It would be great if you could look closely at added examples and commands to be sure they are correct and clear. 