### PR TITLE
EG-1330: correcting permissions for client rpc

### DIFF
--- a/content/en/docs/corda-enterprise/4.0/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.0/clientrpc.md
@@ -174,8 +174,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-3" >}}
 {{% tab name="groovy" %}}
@@ -185,6 +184,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -196,8 +199,7 @@ rpcUsers=[
 
 {{< /tabs >}}
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-4" >}}
 {{% tab name="groovy" %}}
@@ -207,7 +209,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.1/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.1/clientrpc.md
@@ -165,8 +165,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-3" >}}
 {{% tab name="groovy" %}}
@@ -176,6 +175,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -187,8 +190,7 @@ rpcUsers=[
 
 {{< /tabs >}}
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-4" >}}
 {{% tab name="groovy" %}}
@@ -198,7 +200,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.2/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.2/clientrpc.md
@@ -174,8 +174,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-3" >}}
 {{% tab name="groovy" %}}
@@ -185,6 +184,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -196,8 +199,7 @@ rpcUsers=[
 
 {{< /tabs >}}
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-4" >}}
 {{% tab name="groovy" %}}
@@ -207,7 +209,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.3/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.3/clientrpc.md
@@ -166,11 +166,9 @@ rpcUsers=[
 
 By default, RPC users are not permissioned to perform any RPC operations.
 
-
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -178,6 +176,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -186,8 +188,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -195,7 +196,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
@@ -158,11 +158,9 @@ rpcUsers=[
 
 By default, RPC users are not permissioned to perform any RPC operations.
 
-
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -170,6 +168,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -178,8 +180,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -187,7 +188,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
@@ -146,7 +146,7 @@ By default, RPC users are not allowed to perform any RPC operations.
 
 ### Granting flow permissions
 
-In order to provide an RPC user with the permission to start a specific flow, the following syntax can be used: `StartFlow.<fully qualified flow name>` , e.g.:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -154,6 +154,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -162,7 +166,7 @@ rpcUsers=[
 ]
 ```
 
-In order to provide an RPC user with the permission to start any flow, the following syntax can be used: `InvokeRpc.startFlow`, e.g.:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -170,7 +174,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
@@ -152,7 +152,7 @@ By default, RPC users are not allowed to perform any RPC operations.
 
 #### Granting flow permissions
 
-To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, as shown in the following example:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -160,6 +160,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -168,7 +172,7 @@ rpcUsers=[
 ]
 ```
 
-To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, as shown in the following example:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -176,7 +180,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
@@ -152,7 +152,7 @@ By default, RPC users are not allowed to perform any RPC operations.
 
 #### Granting flow permissions
 
-To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, as shown in the following example:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -160,6 +160,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -168,7 +172,7 @@ rpcUsers=[
 ]
 ```
 
-To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, as shown in the following example:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -176,7 +180,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...


### PR DESCRIPTION
This PR updates the documentation for https://r3-cev.atlassian.net/browse/EG-1330 and https://r3-cev.atlassian.net/browse/ENT-4825. It covers only the documentation for 4.0 to 4.7. 4.8 will be covered in another PR. Pre-4.0 documentation will not be updated.