### PR TITLE
DOC-1693: adding documentation on fixing RPC permissions

### DIFF
--- a/content/en/docs/corda-enterprise/4.0/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.0/clientrpc.md
@@ -249,6 +249,18 @@ rpcUsers=[
 
 {{< /tabs >}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.0/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.0/clientrpc.md
@@ -257,7 +257,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.1/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.1/clientrpc.md
@@ -248,7 +248,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.1/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.1/clientrpc.md
@@ -240,6 +240,18 @@ rpcUsers=[
 
 {{< /tabs >}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.2/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.2/clientrpc.md
@@ -249,6 +249,18 @@ rpcUsers=[
 
 {{< /tabs >}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.2/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.2/clientrpc.md
@@ -257,7 +257,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.3/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.3/clientrpc.md
@@ -228,6 +228,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.3/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.3/clientrpc.md
@@ -236,7 +236,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
@@ -220,6 +220,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.4/node/operating/clientrpc.md
@@ -228,7 +228,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
@@ -257,6 +257,19 @@ Syntax `InvokeRpc:com.fully.qualified.package.Alpha#READ_ONLY` will grant permis
 Permission strings are case-insensitive.
 {{% /note %}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
+
 ### Granting all permissions
 
 In order to provide an RPC user with the permission to perform any RPC operation (including starting any flow) use the `ALL` permission:

--- a/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.5/node/operating/clientrpc.md
@@ -265,7 +265,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
@@ -192,8 +192,17 @@ rpcUsers=[
 ]
 ```
 
+#### Fixing permissions
 
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
 
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 
 #### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.6/node/operating/clientrpc.md
@@ -200,7 +200,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
@@ -192,8 +192,17 @@ rpcUsers=[
 ]
 ```
 
+#### Fixing permissions
 
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
 
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 
 #### Granting all permissions
 

--- a/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
+++ b/content/en/docs/corda-enterprise/4.7/node/operating/clientrpc.md
@@ -200,7 +200,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.0/clientrpc.md
+++ b/content/en/docs/corda-os/4.0/clientrpc.md
@@ -165,8 +165,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-3" >}}
 {{% tab name="groovy" %}}
@@ -176,6 +175,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -187,8 +190,8 @@ rpcUsers=[
 
 {{< /tabs >}}
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
+
 
 {{< tabs name="tabs-4" >}}
 {{% tab name="groovy" %}}
@@ -198,7 +201,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     }
     ...

--- a/content/en/docs/corda-os/4.0/clientrpc.md
+++ b/content/en/docs/corda-os/4.0/clientrpc.md
@@ -233,6 +233,18 @@ rpcUsers=[
 
 {{< /tabs >}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.0/clientrpc.md
+++ b/content/en/docs/corda-os/4.0/clientrpc.md
@@ -249,7 +249,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.1/clientrpc.md
+++ b/content/en/docs/corda-os/4.1/clientrpc.md
@@ -165,8 +165,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 {{< tabs name="tabs-3" >}}
 {{% tab name="groovy" %}}
@@ -176,6 +175,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -187,8 +190,8 @@ rpcUsers=[
 
 {{< /tabs >}}
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
+
 
 {{< tabs name="tabs-4" >}}
 {{% tab name="groovy" %}}
@@ -198,7 +201,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.1/clientrpc.md
+++ b/content/en/docs/corda-os/4.1/clientrpc.md
@@ -233,6 +233,18 @@ rpcUsers=[
 
 {{< /tabs >}}
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.1/clientrpc.md
+++ b/content/en/docs/corda-os/4.1/clientrpc.md
@@ -249,7 +249,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.3/clientrpc.md
+++ b/content/en/docs/corda-os/4.3/clientrpc.md
@@ -213,6 +213,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.3/clientrpc.md
+++ b/content/en/docs/corda-os/4.3/clientrpc.md
@@ -228,7 +228,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.3/clientrpc.md
+++ b/content/en/docs/corda-os/4.3/clientrpc.md
@@ -160,8 +160,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -169,6 +168,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -177,8 +180,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -186,7 +188,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.4/clientrpc.md
+++ b/content/en/docs/corda-os/4.4/clientrpc.md
@@ -233,7 +233,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.4/clientrpc.md
+++ b/content/en/docs/corda-os/4.4/clientrpc.md
@@ -218,6 +218,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.4/clientrpc.md
+++ b/content/en/docs/corda-os/4.4/clientrpc.md
@@ -165,8 +165,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -174,6 +173,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -182,8 +185,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -191,7 +193,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.5/clientrpc.md
+++ b/content/en/docs/corda-os/4.5/clientrpc.md
@@ -210,6 +210,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.5/clientrpc.md
+++ b/content/en/docs/corda-os/4.5/clientrpc.md
@@ -225,7 +225,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.5/clientrpc.md
+++ b/content/en/docs/corda-os/4.5/clientrpc.md
@@ -157,8 +157,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -166,6 +165,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -174,8 +177,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -183,7 +185,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.6/clientrpc.md
+++ b/content/en/docs/corda-os/4.6/clientrpc.md
@@ -210,6 +210,18 @@ rpcUsers=[
 ]
 ```
 
+### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 ### Granting all permissions
 

--- a/content/en/docs/corda-os/4.6/clientrpc.md
+++ b/content/en/docs/corda-os/4.6/clientrpc.md
@@ -154,11 +154,9 @@ rpcUsers=[
 
 By default, RPC users are not permissioned to perform any RPC operations.
 
-
 ### Granting flow permissions
 
-You provide an RPC user with the permission to start a specific flow using the syntax
-`StartFlow.<fully qualified flow name>`:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -166,6 +164,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -174,8 +176,7 @@ rpcUsers=[
 ]
 ```
 
-You can also provide an RPC user with the permission to start any flow using the syntax
-`InvokeRpc.startFlow`:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -183,7 +184,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.6/clientrpc.md
+++ b/content/en/docs/corda-os/4.6/clientrpc.md
@@ -224,7 +224,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 

--- a/content/en/docs/corda-os/4.7/clientrpc.md
+++ b/content/en/docs/corda-os/4.7/clientrpc.md
@@ -192,6 +192,18 @@ rpcUsers=[
 ]
 ```
 
+#### Fixing permissions
+
+If an RPC user tries to perform an RPC operation that they do not have permission for, they will see an error like this:
+
+```
+User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
+```
+
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+
+In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
+
 
 #### Granting all permissions
 

--- a/content/en/docs/corda-os/4.7/clientrpc.md
+++ b/content/en/docs/corda-os/4.7/clientrpc.md
@@ -143,7 +143,7 @@ By default, RPC users are not permissioned to perform any RPC operations.
 
 #### Granting flow permissions
 
-To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, as shown in the following example:
+To grant an RPC user permission to start a specific flow, use the syntax `StartFlow.<fully qualified flow name>`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -151,6 +151,10 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
             "StartFlow.net.corda.flows.ExampleFlow1",
             "StartFlow.net.corda.flows.ExampleFlow2"
         ]
@@ -159,7 +163,7 @@ rpcUsers=[
 ]
 ```
 
-To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, as shown in the following example:
+To grant an RPC user permission to start any flow, use the syntax `InvokeRpc.startFlow`, `InvokeRpc.startTrackedFlowDynamic`, and the listed `InvokeRpc` permissions, as shown in the following example:
 
 ```groovy
 rpcUsers=[
@@ -167,7 +171,12 @@ rpcUsers=[
         username=exampleUser
         password=examplePass
         permissions=[
-            "InvokeRpc.startFlow"
+            "InvokeRpc.nodeInfo",
+            "InvokeRpc.registeredFlows",
+            "InvokeRpc.partiesFromName",
+            "InvokeRpc.wellKnownPartyFromX500Name",
+            "InvokeRpc.startFlow",
+            "InvokeRpc.startTrackedFlowDynamic"
         ]
     },
     ...

--- a/content/en/docs/corda-os/4.7/clientrpc.md
+++ b/content/en/docs/corda-os/4.7/clientrpc.md
@@ -209,7 +209,7 @@ If an RPC user tries to perform an RPC operation that they do not have permissio
 User not authorized to perform RPC call public abstract net.corda.core.node.services.Vault$Page net.corda.core.messaging.CordaRPCOps.vaultQueryByWithPagingSpec(java.lang.Class,net.corda.core.node.services.vault.QueryCriteria,net.corda.core.node.services.vault.PageSpecification) with target []
 ```
 
-To fix this, you must grant them permissions based on the method name: `InvokeRpc.methodName`, where `methodName` is the method name of the `CordaRPCOps` interface.
+To fix this, you must grant them permissions based on the method name: `InvokeRpc.<method name>`, where `<method name>` is the method name of the `CordaRPCOps` interface.
 
 In this example, the method name is `vaultQueryByWithPagingSpec`, so `InvokeRpc.vaultQueryByWithPagingSpec` must be added to the RPC user's `permissions`.
 


### PR DESCRIPTION
Adding documentation on fixing RPC permissions (DOC-1693) and also adding fixes to the OS documentation that should have been added as part of DOC-875 and ENT-4825.