### PR TITLE
DOC-1810 Fixed a typo in CE 4.6/4.7 Corda secrets pages

### DIFF
--- a/content/en/docs/corda-enterprise/4.6/secrets.md
+++ b/content/en/docs/corda-enterprise/4.6/secrets.md
@@ -13,7 +13,7 @@ weight: 110
 
 This page documents the secrets that are managed and required by a Corda installation. The secrets fall into two categories:
 
-* Cryptogtaphic keys.
+* Cryptographic keys.
 * Passwords.
 
 The relationships between the secrets and Corda components is shown in the following diagram.

--- a/content/en/docs/corda-enterprise/4.7/secrets.md
+++ b/content/en/docs/corda-enterprise/4.7/secrets.md
@@ -13,7 +13,7 @@ weight: 110
 
 This page documents the secrets that are managed and required by a Corda installation. The secrets fall into two categories:
 
-* Cryptogtaphic keys.
+* Cryptographic keys.
 * Passwords.
 
 The relationships between the secrets and Corda components is shown in the following diagram.


### PR DESCRIPTION
* DOC-1810 Fixed a typo CE 4.6/4.7 Corda secrets pages.
* Resolving issue corda/corda-docs#415.