### PR TITLE
DOC-101 Fixed links to contributors lists in github for OS 4.4/4.7

### DIFF
--- a/content/en/docs/corda-os/4.4/contributing-philosophy.md
+++ b/content/en/docs/corda-os/4.4/contributing-philosophy.md
@@ -69,7 +69,7 @@ You can contact our community maintainers in the `#contributing` channel on the 
 ## Existing Contributors
 
 Over two hundred individuals have contributed to the development of Corda. You can find a full list of contributors in the
-[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md).
+[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.4/CONTRIBUTORS.md).
 
 
 ## Transparency and Conflict Policy

--- a/content/en/docs/corda-os/4.4/contributing.md
+++ b/content/en/docs/corda-os/4.4/contributing.md
@@ -186,7 +186,7 @@ the [Community Maintainers](contributing-philosophy.md#community-maintainers) di
 
 
 * (Optional) Open an additional PR to add yourself to the
-[contributors list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md)>
+[contributors list](https://github.com/corda/corda/blob/release/os/4.4/CONTRIBUTORS.md)>
 
 * The format is generally `firstname surname (company)`, but the company can be omitted if desired
 

--- a/content/en/docs/corda-os/4.5/contributing-philosophy.md
+++ b/content/en/docs/corda-os/4.5/contributing-philosophy.md
@@ -66,7 +66,7 @@ You can contact our community maintainers in the `#contributing` channel on the 
 ## Existing Contributors
 
 Over two hundred individuals have contributed to the development of Corda. You can find a full list of contributors in the
-[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md).
+[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.5/CONTRIBUTORS.md).
 
 
 ## Transparency and Conflict Policy

--- a/content/en/docs/corda-os/4.5/contributing.md
+++ b/content/en/docs/corda-os/4.5/contributing.md
@@ -183,7 +183,7 @@ the [Community Maintainers](contributing-philosophy.md#community-maintainers) di
 
 
 * (Optional) Open an additional PR to add yourself to the
-[contributors list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md)
+[contributors list](https://github.com/corda/corda/blob/release/os/4.5/CONTRIBUTORS.md)
 
 * The format is generally `firstname surname (company)`, but the company can be omitted if desired
 

--- a/content/en/docs/corda-os/4.6/contributing-philosophy.md
+++ b/content/en/docs/corda-os/4.6/contributing-philosophy.md
@@ -66,7 +66,7 @@ You can contact our community maintainers in the `#contributing` channel on the 
 ## Existing Contributors
 
 Over two hundred individuals have contributed to the development of Corda. You can find a full list of contributors in the
-[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md).
+[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.6/CONTRIBUTORS.md).
 
 
 ## Transparency and Conflict Policy

--- a/content/en/docs/corda-os/4.6/contributing.md
+++ b/content/en/docs/corda-os/4.6/contributing.md
@@ -182,7 +182,7 @@ the [Community Maintainers](contributing-philosophy.md#community-maintainers) di
 
 
 * (Optional) Open an additional PR to add yourself to the
-[contributors list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md)
+[contributors list](https://github.com/corda/corda/blob/release/os/4.6/CONTRIBUTORS.md)
 
 * The format is generally `firstname surname (company)`, but the company can be omitted if desired
 

--- a/content/en/docs/corda-os/4.7/contributing-philosophy.md
+++ b/content/en/docs/corda-os/4.7/contributing-philosophy.md
@@ -66,7 +66,7 @@ You can contact our community maintainers in the `#contributing` channel on the 
 ## Existing Contributors
 
 Over two hundred individuals have contributed to the development of Corda. You can find a full list of contributors in the
-[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md).
+[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.7/CONTRIBUTORS.md).
 
 
 ## Transparency and Conflict Policy

--- a/content/en/docs/corda-os/4.7/contributing.md
+++ b/content/en/docs/corda-os/4.7/contributing.md
@@ -182,7 +182,7 @@ the [Community Maintainers](contributing-philosophy.md#community-maintainers) di
 
 
 * (Optional) Open an additional PR to add yourself to the
-[contributors list](https://github.com/corda/corda/blob/master/CONTRIBUTORS.md)
+[contributors list](https://github.com/corda/corda/blob/release/os/4.7/CONTRIBUTORS.md)
 
 * The format is generally `firstname surname (company)`, but the company can be omitted if desired
 


### PR DESCRIPTION
DOC-101 Fixed links to contributors lists in github for OS 4.4/4.7