### PR TITLE
DOC-2077 Fixes to node management console & flow management console pages

### DIFF
--- a/content/en/docs/corda-enterprise/4.7/node/management-console/index.md
+++ b/content/en/docs/corda-enterprise/4.7/node/management-console/index.md
@@ -1,4 +1,5 @@
 ---
+date: '2020-04-07T12:00:00Z'
 menu:
   corda-enterprise-4-7:
     parent: corda-enterprise-4-7-corda-nodes
@@ -7,8 +8,8 @@ tags:
 - administration
 title: Node management console
 weight: 76
-
 ---
+
 # Node management console
 
 The Node management console allows you to see information about a node and perform some operations on it. It runs as a plug-in for the [Gateway Service](../gateway-service.md).

--- a/content/en/docs/corda-enterprise/4.7/node/node-flow-management-console.md
+++ b/content/en/docs/corda-enterprise/4.7/node/node-flow-management-console.md
@@ -1,6 +1,5 @@
 ---
-title: "Flow management console"
-linkTitle: "Flow management console"
+date: '2020-04-07T12:00:00Z'
 menu:
   corda-enterprise-4-7:
     parent: corda-enterprise-4-7-corda-nodes-operating
@@ -11,6 +10,7 @@ tags:
 title: Flow management console
 weight: 155
 ---
+
 # Flow management console
 
 The flow management console allows you to see the state of the flows running on a node and perform some operations on them. It runs as part of the [Gateway Service](gateway-service.md).

--- a/content/en/docs/corda-enterprise/4.8/node/management-console/index.md
+++ b/content/en/docs/corda-enterprise/4.8/node/management-console/index.md
@@ -1,4 +1,5 @@
 ---
+date: '2020-04-07T12:00:00Z'
 menu:
   corda-enterprise-4-8:
     parent: corda-enterprise-4-8-corda-nodes
@@ -7,8 +8,8 @@ tags:
 - administration
 title: Node management console
 weight: 76
-
 ---
+
 # Node management console
 
 The Node management console allows you to see information about a node and perform some operations on it. It runs as a plug-in for the [Gateway Service](../gateway-service.md).

--- a/content/en/docs/corda-enterprise/4.8/node/node-flow-management-console.md
+++ b/content/en/docs/corda-enterprise/4.8/node/node-flow-management-console.md
@@ -1,6 +1,5 @@
 ---
-title: "Flow management console"
-linkTitle: "Flow management console"
+date: '2020-04-07T12:00:00Z'
 menu:
   corda-enterprise-4-8:
     parent: corda-enterprise-4-8-corda-nodes-operating
@@ -11,6 +10,7 @@ tags:
 title: Flow management console
 weight: 155
 ---
+
 # Flow management console
 
 The flow management console allows you to see the state of the flows running on a node and perform some operations on them. It runs as part of the [Gateway Service](gateway-service.md).


### PR DESCRIPTION
DOC-2077 Fixes to front matter and file name of the node management console page, and the front matter of the flow management console page for CE 4.7 and 4.8